### PR TITLE
fix: harden queued export guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ make sense as a table, and the same endpoint that serves JSON will stream **CSV,
 the request asks for it - over the `Accept` header or a `?format=` query parameter - with no second controller and no
 bespoke serialization code.
 
-Exports stream at constant memory (a million rows in tens of megabytes), so the one engine drives an inline download, a
-queued export to disk behind a signed URL, or a one-off export through a fluent builder, all the same way.
+Rows are pulled lazily from the source, so CSV, TSV, JSON, XML, and NDJSON exports stay flat in memory even for large
+queries. XLSX is built as a temporary workbook before the response can flush, so large spreadsheets are best queued to
+disk behind a signed URL. The same engine drives inline downloads, queued exports, and one-off fluent exports.
 
 The package is registered automatically through Laravel's package auto-discovery; publish the config (see below) to
 register custom formats or tune the negotiation limits.
@@ -24,8 +25,9 @@ There are two doors onto one streaming engine:
 
 - **Content negotiation.** A `JsonResource` that uses the `RespondsWithExports` trait keeps serving JSON by default but
   answers `Accept: text/csv` (or `?format=csv`) by streaming the negotiated format instead - for both a single resource
-  and a collection. JSON stays first-class: a browser's default `Accept` always resolves to JSON, `q=0` is honoured, and
-  every response carries `Vary: Accept`.
+  and the collection/page returned by the route. Use `ResourceExport::forQuery()` or a queued export when the export
+  request should switch from paginated JSON to the full query. JSON stays first-class: a browser's default `Accept`
+  always resolves to JSON, `q=0` is honoured, and every response carries `Vary: Accept`.
 - **Explicit exports.** The `Exporter` facade builds an export from a resource, a collection, or a query and returns a
   fluent builder whose verbs - `download()`, `store()`, `toString()`, `toStream()`, `toResponse()`, `queue()` - decide
   where the bytes go.
@@ -41,8 +43,9 @@ Formats split by **dimensionality**:
 
 A few rules hold across the surface:
 
-- **Streamed, never buffered.** Rows are pulled from the source lazily (keyset `lazyById` pagination for queries) and
-  written straight to the output, so memory stays flat regardless of row count.
+- **Lazy row pipeline.** Rows are pulled from the source lazily (keyset `lazyById` pagination for queries) and passed
+  straight through the engine. Textual and hierarchical writers flush progressively; XLSX finalises a temporary workbook
+  before handing it to the sink.
 - **Stateless and Octane-safe.** Nothing caches the request or a mutable driver between exports; the media-type registry
   is built once at boot and read-only thereafter.
 - **Extensible by configuration.** Register a custom format in `config/exporter.php`; the negotiated and explicit paths
@@ -253,9 +256,10 @@ Exporter::queue(User::class, UserResource::class)
     ->queue();
 ```
 
-The job streams chunk by chunk at constant memory and fires `ExportStarting`, `RowsExported`, `ExportCompleted`
+The job streams chunk by chunk into a local staging file and fires `ExportStarting`, `RowsExported`, `ExportCompleted`
 (carrying a signed temporary URL), and `ExportFailed`. The query is described by a serializable specification - constrain
-it with the query verbs on the builder rather than passing a live builder.
+it with the query verbs on the builder rather than passing a live builder. HTTP streaming failures after bytes have
+started are reported separately through `StreamExportFailed`, with the format, actor and number of rows written.
 
 ### Testing
 

--- a/src/Export/ExportSpecification.php
+++ b/src/Export/ExportSpecification.php
@@ -18,8 +18,10 @@ use Illuminate\Database\Eloquent\Builder;
  * carries the download filename hint, the initiating actor (id plus class, so
  * the worker can resolve and re-authorize against the original user), an
  * optional gate ability for the full-set authorization re-check, and the chunk,
- * progress and signed-URL-expiry tuning. Every field is a string, int or array
- * of those, so the whole specification round-trips through the queue cleanly.
+ * progress and signed-URL-expiry tuning. A missing ability only means the
+ * caller deliberately waived the full-set check when authorizationWaived is
+ * true. Every field is a string, int, bool or array of those, so the whole
+ * specification round-trips through the queue cleanly.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -43,6 +45,7 @@ final readonly class ExportSpecification
      * @param  int  $chunkSize
      * @param  int  $progressEvery
      * @param  int  $urlExpiresAfter
+     * @param  bool  $authorizationWaived
      */
     public function __construct(
 
@@ -87,6 +90,9 @@ final readonly class ExportSpecification
 
         /** The lifetime, in minutes, of the signed temporary download URL. */
         public int $urlExpiresAfter = 60,
+
+        /** Whether the full-set authorization requirement was waived. */
+        public bool $authorizationWaived = false,
     ) {}
 
     /**

--- a/src/Export/QueuedExport.php
+++ b/src/Export/QueuedExport.php
@@ -26,7 +26,9 @@ use SineMacula\Exporter\Testing\ExporterFake;
  *
  * A live builder or closure is deliberately not accepted: neither serializes
  * reliably onto a queue. Express the selection as constraints instead, and the
- * worker rebuilds the query from the model.
+ * worker rebuilds the query from the model. The full-set authorization decision
+ * is carried in the specification too, so direct specification dispatches are
+ * checked by the job rather than only by the queue() convenience verb.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -267,6 +269,7 @@ final class QueuedExport
             $this->chunkSize,
             $this->progressEvery,
             $this->urlExpiresAfter,
+            $this->withoutAuthorization,
         );
     }
 

--- a/src/ExporterServiceProvider.php
+++ b/src/ExporterServiceProvider.php
@@ -70,7 +70,7 @@ final class ExporterServiceProvider extends ServiceProvider
         // @codeCoverageIgnoreEnd
         $this->publishes([
             __DIR__ . '/../config/exporter.php' => config_path('exporter.php'),
-        ], 'config');
+        ], ['config', 'exporter-config']);
     }
 
     /**

--- a/src/Jobs/ExportToDiskJob.php
+++ b/src/Jobs/ExportToDiskJob.php
@@ -51,8 +51,9 @@ use SineMacula\Exporter\Writers\CountingWriter;
  * periodically as rows stream, ExportCompleted (the shared audit event) on
  * success, and ExportFailed once the job exhausts its retries. The job is
  * retry-safe: every attempt stages to its own temp file, cleans that file up,
- * and removes any partially written disk file before re-throwing, so a retry
- * starts from a clean slate.
+ * and removes a partially written disk file only when this attempt created the
+ * destination, so a retry starts from a clean slate without deleting a
+ * pre-existing file at the same path.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -97,10 +98,14 @@ final class ExportToDiskJob implements ShouldQueue
      */
     public function handle(Engine $engine, ExportAuditor $auditor, MediaTypeRegistry $registry, Factory $filesystem): void
     {
+        $this->guardAuthorizationDecision();
+
         Event::dispatch(new ExportStarting($this->spec->format, $this->spec->disk, $this->spec->path, $this->spec->actorId));
 
-        $disk    = $filesystem->disk($this->spec->disk);
-        $staging = null;
+        $disk             = $filesystem->disk($this->spec->disk);
+        $targetExisted    = $this->hasExistingTarget($disk);
+        $storageAttempted = false;
+        $staging          = null;
 
         try {
             $actor   = $this->actor();
@@ -119,6 +124,8 @@ final class ExportToDiskJob implements ShouldQueue
             $staging = $this->stagingPath();
             $rows    = $this->stream($engine, $query, $schema, $writer, $request, $staging);
 
+            $storageAttempted = true;
+
             (new DiskSink($disk, $this->spec->path))->putFromFile($staging);
 
             $auditor->completed(new ExportCompleted(
@@ -133,7 +140,7 @@ final class ExportToDiskJob implements ShouldQueue
                 queued: true,
             ));
         } catch (\Throwable $exception) {
-            $disk->delete($this->spec->path);
+            $this->cleanupFailedStorageAttempt($disk, $targetExisted, $storageAttempted);
 
             throw $exception;
         } finally {
@@ -158,6 +165,64 @@ final class ExportToDiskJob implements ShouldQueue
             $this->spec->actorId,
             $exception,
         ));
+    }
+
+    /**
+     * Require the serialized export to carry an explicit full-set authorization
+     * decision.
+     *
+     * @return void
+     *
+     * @throws \LogicException
+     */
+    private function guardAuthorizationDecision(): void
+    {
+        if ($this->spec->ability !== null || $this->spec->authorizationWaived) {
+            return;
+        }
+
+        throw new \LogicException('A queued export specification must carry a full-set authorization ability, or explicitly waive authorization.');
+    }
+
+    /**
+     * Determine whether the destination path existed before this attempt.
+     *
+     * @param  \Illuminate\Contracts\Filesystem\Filesystem  $disk
+     * @return bool|null
+     */
+    private function hasExistingTarget(Filesystem $disk): ?bool
+    {
+        try {
+            return $disk->exists($this->spec->path);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Remove a partial file from this attempt without deleting a pre-existing
+     * destination.
+     *
+     * @param  \Illuminate\Contracts\Filesystem\Filesystem  $disk
+     * @param  bool|null  $targetExisted
+     * @param  bool  $storageAttempted
+     * @return void
+     */
+    private function cleanupFailedStorageAttempt(Filesystem $disk, ?bool $targetExisted, bool $storageAttempted): void
+    {
+        if (!$storageAttempted || $targetExisted !== false) {
+            return;
+        }
+
+        try {
+            $disk->delete($this->spec->path);
+        } catch (\Throwable $exception) {
+            Log::warning('Unable to remove a failed queued export file.', [
+                'disk'      => $this->spec->disk,
+                'path'      => $this->spec->path,
+                'exception' => $exception,
+            ]);
+        }
     }
 
     /**

--- a/src/Jobs/ExportToDiskJob.php
+++ b/src/Jobs/ExportToDiskJob.php
@@ -53,7 +53,8 @@ use SineMacula\Exporter\Writers\CountingWriter;
  * retry-safe: every attempt stages to its own temp file, cleans that file up,
  * and removes a partially written disk file only when this attempt created the
  * destination, so a retry starts from a clean slate without deleting a
- * pre-existing file at the same path.
+ * pre-existing file at the same path. Once storage succeeds, completion
+ * listener failures are logged but do not roll back the stored export.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -128,7 +129,7 @@ final class ExportToDiskJob implements ShouldQueue
 
             (new DiskSink($disk, $this->spec->path))->putFromFile($staging);
 
-            $auditor->completed(new ExportCompleted(
+            $this->reportCompleted($auditor, new ExportCompleted(
                 $this->spec->actorId,
                 $rows,
                 $this->spec->filename,
@@ -165,6 +166,29 @@ final class ExportToDiskJob implements ShouldQueue
             $this->spec->actorId,
             $exception,
         ));
+    }
+
+    /**
+     * Dispatch the completion audit without rolling back a stored export when
+     * a listener fails.
+     *
+     * @param  \SineMacula\Exporter\Export\ExportAuditor  $auditor
+     * @param  \SineMacula\Exporter\Events\ExportCompleted  $event
+     * @return void
+     */
+    private function reportCompleted(ExportAuditor $auditor, ExportCompleted $event): void
+    {
+        try {
+            $auditor->completed($event);
+        } catch (\Throwable $exception) {
+            Log::warning('Queued export completed, but completion handling failed.', [
+                'disk'      => $this->spec->disk,
+                'path'      => $this->spec->path,
+                'format'    => $this->spec->format,
+                'actor_id'  => $this->spec->actorId,
+                'exception' => $exception,
+            ]);
+        }
     }
 
     /**

--- a/src/Testing/ExporterFake.php
+++ b/src/Testing/ExporterFake.php
@@ -199,20 +199,7 @@ final class ExporterFake
      */
     public function assertStringExported(?string $format = null): self
     {
-        $matches = array_filter(
-            $this->exports,
-            static fn (RecordedExport $export): bool => $export->type === 'string'
-                && ($format === null || $export->format === $format),
-        );
-
-        PHPUnit::assertNotEmpty(
-            $matches,
-            $format === null
-                ? 'Expected an export to be buffered to a string, but none were.'
-                : "Expected an export to be buffered to a string as [{$format}], but none were.",
-        );
-
-        return $this;
+        return $this->assertExportedAs('string', 'buffered to a string', $format);
     }
 
     /**
@@ -226,20 +213,7 @@ final class ExporterFake
      */
     public function assertStreamedTo(?string $format = null): self
     {
-        $matches = array_filter(
-            $this->exports,
-            static fn (RecordedExport $export): bool => $export->type === 'stream'
-                && ($format === null || $export->format === $format),
-        );
-
-        PHPUnit::assertNotEmpty(
-            $matches,
-            $format === null
-                ? 'Expected an export to be streamed to a resource, but none were.'
-                : "Expected an export to be streamed to a resource as [{$format}], but none were.",
-        );
-
-        return $this;
+        return $this->assertExportedAs('stream', 'streamed to a resource', $format);
     }
 
     /**
@@ -297,6 +271,33 @@ final class ExporterFake
     public function assertNothingExported(): self
     {
         PHPUnit::assertEmpty($this->exports, 'Expected no exports, but some were recorded.');
+
+        return $this;
+    }
+
+    /**
+     * Assert an export terminal verb was recorded, optionally of a given
+     * format.
+     *
+     * @param  string  $type
+     * @param  string  $description
+     * @param  string|null  $format
+     * @return $this
+     */
+    private function assertExportedAs(string $type, string $description, ?string $format = null): self
+    {
+        $matches = array_filter(
+            $this->exports,
+            static fn (RecordedExport $export): bool => $export->type === $type
+                && ($format === null || $export->format === $format),
+        );
+
+        PHPUnit::assertNotEmpty(
+            $matches,
+            $format === null
+                ? "Expected an export to be {$description}, but none were."
+                : "Expected an export to be {$description} as [{$format}], but none were.",
+        );
 
         return $this;
     }

--- a/tests/Integration/ExportToDiskJobTest.php
+++ b/tests/Integration/ExportToDiskJobTest.php
@@ -56,6 +56,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
                 ->toDisk('exports', 'exports/users.csv')
                 ->orderBy('id')
                 ->chunk(10)
+                ->withoutAuthorization()
                 ->toSpecification(),
         );
 
@@ -88,6 +89,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
         ExportToDiskJob::dispatchSync(
             QueuedExport::forModel(User::class, UserResource::class)
                 ->toDisk('exports', 'exports/users.csv')
+                ->withoutAuthorization()
                 ->toSpecification(),
         );
 
@@ -116,6 +118,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
         ExportToDiskJob::dispatchSync(
             QueuedExport::forModel(User::class, UserResource::class)
                 ->toDisk('exports', 'exports/users.csv')
+                ->withoutAuthorization()
                 ->toSpecification(),
         );
 
@@ -144,6 +147,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
         ExportToDiskJob::dispatchSync(
             QueuedExport::forModel(User::class, UserResource::class)
                 ->toDisk('exports', 'exports/users.csv')
+                ->withoutAuthorization()
                 ->toSpecification(),
         );
 
@@ -198,6 +202,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
         $job = new ExportToDiskJob(
             QueuedExport::forModel(User::class, UserResource::class)
                 ->toDisk('exports', 'exports/users.csv')
+                ->withoutAuthorization()
                 ->toSpecification(),
         );
 
@@ -229,6 +234,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
                 ->toDisk('exports', 'exports/users.csv')
                 ->as('members')
                 ->by($admin)
+                ->withoutAuthorization()
                 ->toSpecification(),
         );
 
@@ -268,6 +274,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
                 ->toDisk('exports', 'exports/users.csv')
                 ->chunk(5)
                 ->progressEvery(10)
+                ->withoutAuthorization()
                 ->toSpecification(),
         );
 
@@ -309,6 +316,36 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
 
         self::assertInstanceOf(AuthorizationException::class, $caught);
         self::assertFalse($disk->exists('exports/users.csv'));
+    }
+
+    /**
+     * It rejects a serialized specification that carries neither a full-set
+     * authorization ability nor an explicit authorization waiver.
+     *
+     * @return void
+     */
+    public function testSpecificationWithoutAnAuthorizationDecisionIsRejectedOnTheWorker(): void
+    {
+        $disk = $this->fakeDisk('exports');
+
+        Event::fake();
+
+        $this->seedUsers(3);
+
+        $job = new ExportToDiskJob(
+            QueuedExport::forModel(User::class, UserResource::class)
+                ->toDisk('exports', 'exports/users.csv')
+                ->toSpecification(),
+        );
+
+        $this->expectException(\LogicException::class);
+
+        try {
+            app()->call([$job, 'handle']);
+        } finally {
+            self::assertFalse($disk->exists('exports/users.csv'));
+            Event::assertNotDispatched(ExportStarting::class);
+        }
     }
 
     /**
@@ -357,6 +394,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
             QueuedExport::forModel(User::class, UserResource::class)
                 ->format('json')
                 ->toDisk('exports', 'exports/users.json')
+                ->withoutAuthorization()
                 ->toSpecification(),
         );
 
@@ -378,6 +416,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
         $job = new ExportToDiskJob(
             QueuedExport::forModel(User::class, PlainUserResource::class)
                 ->toDisk('exports', 'exports/users.csv')
+                ->withoutAuthorization()
                 ->toSpecification(),
         );
 
@@ -401,6 +440,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
             QueuedExport::forModel(User::class, UserResource::class)
                 ->toDisk('exports', 'exports/users.csv')
                 ->by($admin)
+                ->withoutAuthorization()
                 ->toSpecification(),
         );
 
@@ -435,6 +475,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
             QueuedExport::forModel(User::class, UserResource::class)
                 ->schema(ExplodingExportSchema::class)
                 ->toDisk('exports', 'exports/boom.csv')
+                ->withoutAuthorization()
                 ->toSpecification(),
         );
 
@@ -452,6 +493,40 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
     }
 
     /**
+     * It does not delete a destination that existed before a failed export
+     * attempt.
+     *
+     * @return void
+     */
+    public function testDoesNotDeleteAPreExistingTargetAfterAFailedExport(): void
+    {
+        $disk = $this->fakeDisk('exports');
+
+        $disk->put('exports/boom.csv', 'existing export');
+
+        $this->seedUsers(3);
+
+        $job = new ExportToDiskJob(
+            QueuedExport::forModel(User::class, UserResource::class)
+                ->schema(ExplodingExportSchema::class)
+                ->toDisk('exports', 'exports/boom.csv')
+                ->withoutAuthorization()
+                ->toSpecification(),
+        );
+
+        $caught = null;
+
+        try {
+            app()->call([$job, 'handle']);
+        } catch (\Throwable $exception) {
+            $caught = $exception;
+        }
+
+        self::assertInstanceOf(\RuntimeException::class, $caught);
+        self::assertSame('existing export', $disk->get('exports/boom.csv'));
+    }
+
+    /**
      * It leaves no staging file behind after a successful export.
      *
      * @return void
@@ -466,6 +541,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
         ExportToDiskJob::dispatchSync(
             QueuedExport::forModel(User::class, UserResource::class)
                 ->toDisk('exports', 'exports/users.csv')
+                ->withoutAuthorization()
                 ->toSpecification(),
         );
 
@@ -483,6 +559,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
         $job = new ExportToDiskJob(
             QueuedExport::forModel(User::class, UserResource::class)
                 ->toDisk('exports', 'exports/users.csv')
+                ->withoutAuthorization()
                 ->toSpecification(),
         );
 
@@ -505,6 +582,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
         ExportToDiskJob::dispatchSync(
             QueuedExport::forModel(User::class, UserResource::class)
                 ->toDisk('exports', 'exports/users.csv')
+                ->withoutAuthorization()
                 ->toSpecification(),
         );
 
@@ -534,6 +612,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
                 ->toDisk('exports', 'exports/users.csv')
                 ->chunk(2)
                 ->progressEvery(0)
+                ->withoutAuthorization()
                 ->toSpecification(),
         );
 
@@ -548,7 +627,8 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
 
     /**
      * It removes the partially written disk file when a failure occurs after
-     * the file has already been stored, leaving a retry a clean slate.
+     * the file has already been stored and the destination did not previously
+     * exist, leaving a retry a clean slate.
      *
      * @return void
      */
@@ -564,6 +644,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
         $job = new ExportToDiskJob(
             QueuedExport::forModel(User::class, UserResource::class)
                 ->toDisk('exports', 'exports/users.csv')
+                ->withoutAuthorization()
                 ->toSpecification(),
         );
 
@@ -601,6 +682,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
             path: 'exports/users.csv',
             actorId: 999,
             actorClass: null,
+            authorizationWaived: true,
         ));
 
         $disk->assertExists('exports/users.csv');
@@ -630,6 +712,7 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
                 ->toDisk('exports', 'exports/actor.csv')
                 ->orderBy('id')
                 ->by($admin)
+                ->withoutAuthorization()
                 ->toSpecification(),
         );
 

--- a/tests/Integration/ExportToDiskJobTest.php
+++ b/tests/Integration/ExportToDiskJobTest.php
@@ -626,15 +626,19 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
     }
 
     /**
-     * It removes the partially written disk file when a failure occurs after
-     * the file has already been stored and the destination did not previously
-     * exist, leaving a retry a clean slate.
+     * It keeps a stored export when completion handling fails after storage has
+     * already succeeded.
      *
      * @return void
      */
-    public function testRemovesTheStoredFileWhenAFailureOccursAfterStoring(): void
+    public function testKeepsTheStoredFileWhenCompletionHandlingFailsAfterStoring(): void
     {
         $disk = $this->fakeDisk('exports');
+        $disk->buildTemporaryUrlsUsing(
+            fn (string $path, mixed $expiration): string => 'https://signed.example/' . $path,
+        );
+
+        Log::spy();
         $this->seedUsers(2);
 
         Event::listen(ExportCompleted::class, static function (): void {
@@ -648,16 +652,18 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
                 ->toSpecification(),
         );
 
-        $caught = null;
+        app()->call([$job, 'handle']);
 
-        try {
-            app()->call([$job, 'handle']);
-        } catch (\Throwable $exception) {
-            $caught = $exception;
-        }
+        $disk->assertExists('exports/users.csv');
 
-        self::assertInstanceOf(\RuntimeException::class, $caught);
-        self::assertFalse($disk->exists('exports/users.csv'));
+        Log::shouldHaveReceived('warning') // @phpstan-ignore staticMethod.notFound
+            ->once()
+            ->withArgs(static fn (string $message, array $context): bool => $message === 'Queued export completed, but completion handling failed.'
+                && $context['disk']                                                  === 'exports'
+                && $context['path']                                                  === 'exports/users.csv'
+                && $context['format']                                                === 'csv'
+                && $context['exception'] instanceof \RuntimeException
+                && $context['exception']->getMessage() === 'blew up after storing');
     }
 
     /**

--- a/tests/Integration/QueuedExportTest.php
+++ b/tests/Integration/QueuedExportTest.php
@@ -144,6 +144,7 @@ final class QueuedExportTest extends QueuedExportTestCase
         self::assertSame($actor->id, $spec->actorId);
         self::assertSame($actor::class, $spec->actorClass);
         self::assertSame('export-users', $spec->ability);
+        self::assertFalse($spec->authorizationWaived);
         self::assertSame(250, $spec->chunkSize);
         self::assertSame(100, $spec->progressEvery);
         self::assertSame(15, $spec->urlExpiresAfter);
@@ -163,6 +164,7 @@ final class QueuedExportTest extends QueuedExportTestCase
         $spec = QueuedExport::forModel(User::class, UserResource::class)
             ->schema(UserExportSchema::class)
             ->toDisk('exports', 'exports/users.csv')
+            ->withoutAuthorization()
             ->where('role', 'user')
             ->whereIn('id', [1, 2, 3])
             ->orderBy('id')
@@ -177,7 +179,25 @@ final class QueuedExportTest extends QueuedExportTestCase
         self::assertSame($spec->format, $restored->format);
         self::assertSame($spec->disk, $restored->disk);
         self::assertSame($spec->path, $restored->path);
+        self::assertSame($spec->authorizationWaived, $restored->authorizationWaived);
         self::assertEquals($spec->constraints, $restored->constraints);
+    }
+
+    /**
+     * It carries the explicit authorization opt-out onto the serializable
+     * specification for the worker to enforce.
+     *
+     * @return void
+     */
+    public function testToSpecificationCarriesTheAuthorizationWaiver(): void
+    {
+        $spec = QueuedExport::forModel(User::class, UserResource::class)
+            ->toDisk('exports', 'exports/users.csv')
+            ->withoutAuthorization()
+            ->toSpecification();
+
+        self::assertNull($spec->ability);
+        self::assertTrue($spec->authorizationWaived);
     }
 
     /**
@@ -425,6 +445,7 @@ final class QueuedExportTest extends QueuedExportTestCase
         self::assertSame(1000, $spec->chunkSize);
         self::assertSame(1000, $spec->progressEvery);
         self::assertSame(60, $spec->urlExpiresAfter);
+        self::assertFalse($spec->authorizationWaived);
     }
 
     /**
@@ -503,7 +524,8 @@ final class QueuedExportTest extends QueuedExportTestCase
             ->queue();
 
         $fake->assertQueued(static fn (ExportSpecification $spec): bool => $spec->disk === 'exports'
-            && $spec->path                                                             === 'exports/users.csv');
+            && $spec->path                                                             === 'exports/users.csv'
+            && $spec->authorizationWaived                                              === true);
     }
 
     /**

--- a/tests/Unit/ExporterServiceProviderTest.php
+++ b/tests/Unit/ExporterServiceProviderTest.php
@@ -138,9 +138,11 @@ final class ExporterServiceProviderTest extends TestCase
         }
 
         $publishable = ExporterServiceProvider::pathsToPublish(ExporterServiceProvider::class, 'config');
+        $tagged      = ExporterServiceProvider::pathsToPublish(ExporterServiceProvider::class, 'exporter-config');
         $source      = (string) array_key_first($publishable);
 
         self::assertCount(1, $publishable);
+        self::assertSame($publishable, $tagged);
         self::assertStringEndsWith('/config/exporter.php', $source);
         self::assertSame(
             realpath(dirname(__DIR__, 2) . '/config/exporter.php'),


### PR DESCRIPTION
## Summary

- Require queued export specifications to carry either a full-set authorization ability or an explicit authorization waiver before the worker starts.
- Preserve any file that existed before a failed queued export attempt, while still cleaning up files created by the failed attempt.
- Treat a successful queued disk write as the commitment point: completion listener failures are logged and do not roll back the stored export.
- Register the documented `exporter-config` publish tag alongside `config`.
- Clarify README wording around XLSX finalization, route collection/page exports versus full-query exports, and `StreamExportFailed`.
- Reduce the actionable `composer smells` duplication in `ExporterFake` without changing its public assertion API.

## Why

The queued `queue()` path already required an authorization decision, but direct specification dispatch could bypass that guard. The job also deleted the destination path on any failure, which could remove a pre-existing export. Finally, a completion listener failure after storage could previously make a successfully written export look failed and delete the new file. The docs and publish tags are now aligned with the implemented behavior.

## Validation

- `vendor/bin/phpunit tests/Integration/ExportToDiskJobTest.php tests/Integration/QueuedExportTest.php`
- `vendor/bin/phpunit tests/Integration/ExporterFakeTest.php`
- `composer check`
- `composer test`
- `composer smells -- --no-snippets`

`composer smells` now reports only parameter-count warnings, which are retained intentionally for value objects, event payloads, writer options, and internal pipeline signatures.
