### PR TITLE
style: reflow docblock prose

### DIFF
--- a/benchmarks/Support/RowFactory.php
+++ b/benchmarks/Support/RowFactory.php
@@ -7,8 +7,8 @@ namespace Benchmarks\Support;
 /**
  * Builds representative row datasets for the exporter benchmarks.
  *
- * Produces a list of associative rows with a handful of mixed scalar columns
- * so the exporter benches exercise the real filter, escape and serialize paths.
+ * Produces a list of associative rows with a handful of mixed scalar columns so
+ * the exporter benches exercise the real filter, escape and serialize paths.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Contracts/DerivesAggregates.php
+++ b/src/Contracts/DerivesAggregates.php
@@ -15,8 +15,7 @@ use SineMacula\Exporter\Schema\EagerLoadPlan;
  * The engine inspects the schema's columns, builds an EagerLoadPlan, and
  * applies it only to sources that implement this, so a count or sum column
  * carries its value end to end without the caller wiring the eager-load by
- * hand. Sources that wrap already-materialised data simply do not implement
- * it.
+ * hand. Sources that wrap already-materialised data simply do not implement it.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Contracts/ExportFactory.php
+++ b/src/Contracts/ExportFactory.php
@@ -8,9 +8,9 @@ namespace SineMacula\Exporter\Contracts;
  * Export factory contract.
  *
  * The public surface of the export manager, bound in the container under this
- * interface so the documented `app(...)->extend(...)` and constructor
- * injection resolve the same singleton. Implemented additively by the existing
- * manager; v2 behaviour is unchanged.
+ * interface so the documented `app(...)->extend(...)` and constructor injection
+ * resolve the same singleton. Implemented additively by the existing manager;
+ * v2 behaviour is unchanged.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Contracts/Sink.php
+++ b/src/Contracts/Sink.php
@@ -9,9 +9,9 @@ namespace SineMacula\Exporter\Contracts;
  *
  * The destination bytes are written to (string buffer, php://output, a
  * StreamedResponse, or a storage disk / temp file). Seekable stream sinks
- * support direct streaming; non-seekable sinks require the
- * finalise-then-upload path (an XLSX is a ZIP closed on finalisation, and
- * remote disks cannot be streamed to in place).
+ * support direct streaming; non-seekable sinks require the finalise-then-upload
+ * path (an XLSX is a ZIP closed on finalisation, and remote disks cannot be
+ * streamed to in place).
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Contracts/Writer.php
+++ b/src/Contracts/Writer.php
@@ -9,10 +9,10 @@ use SineMacula\Exporter\Schema\TabularSchema;
 /**
  * Writer contract.
  *
- * Streams a tabular representation into bytes for a single media type. A
- * writer is constructed per export, holds no request state, and emits rows
- * already shaped by the schema (a map of column key to typed cell value) one
- * at a time so the response stays at constant memory.
+ * Streams a tabular representation into bytes for a single media type. A writer
+ * is constructed per export, holds no request state, and emits rows already
+ * shaped by the schema (a map of column key to typed cell value) one at a time
+ * so the response stays at constant memory.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Events/StreamExportFailed.php
+++ b/src/Events/StreamExportFailed.php
@@ -13,8 +13,8 @@ namespace SineMacula\Exporter\Events;
  * response cannot retract headers or become a clean error, so the writer
  * flushes a documented truncation marker into the body and the engine fires
  * this event carrying the row context (the format and the number of data rows
- * that reached the client before the failure) plus the actor and the
- * underlying exception, so a listener can alert, audit, or compensate.
+ * that reached the client before the failure) plus the actor and the underlying
+ * exception, so a listener can alert, audit, or compensate.
  *
  * It is distinct from ExportFailed: there is no disk or path because a streamed
  * export has no stored file, and rowsWritten records exactly how much of the

--- a/src/Exceptions/InvalidExportSchema.php
+++ b/src/Exceptions/InvalidExportSchema.php
@@ -9,10 +9,10 @@ namespace SineMacula\Exporter\Exceptions;
  *
  * Thrown in preflight strictness when a schema cannot be honoured: a column
  * with an empty key or an unresolvable cast, or a row-expansion declaration
- * with no relation to expand. Preflight fails fast here, before any bytes
- * are streamed, because a streamed response cannot emit a clean error
- * mid-body; the lenient mode skips the offending column or disables
- * expansion and records a warning instead.
+ * with no relation to expand. Preflight fails fast here, before any bytes are
+ * streamed, because a streamed response cannot emit a clean error mid-body; the
+ * lenient mode skips the offending column or disables expansion and records a
+ * warning instead.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/ExportBuilder.php
+++ b/src/ExportBuilder.php
@@ -36,9 +36,9 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 /**
  * Fluent explicit-export builder.
  *
- * The single, top-level entry point for an explicit (non-negotiated) export.
- * It composes the existing pieces rather than re-implementing them: a subject
- * (a resource item, a resource collection, or an Eloquent query) is normalised
+ * The single, top-level entry point for an explicit (non-negotiated) export. It
+ * composes the existing pieces rather than re-implementing them: a subject (a
+ * resource item, a resource collection, or an Eloquent query) is normalised
  * into a Source adapter, a format selects a Writer from the media registry, and
  * a tabular schema (declared explicitly, or resolved from the resource) drives
  * the Engine; the shaped rows stream into whichever Sink the chosen verb wants.

--- a/src/Http/FormatResolver.php
+++ b/src/Http/FormatResolver.php
@@ -15,8 +15,8 @@ use Symfony\Component\HttpFoundation\AcceptHeader;
  * used). Precedence is: an explicit ?format= query parameter or a whitelisted
  * URL extension, then the Accept header at its highest quality (filtering q=0
  * entries), then the configured default. JSON is a first-class candidate so a
- * wildcard or empty Accept resolves to it. The resolver is request-explicit
- * and holds no per-request state, so it is safe to reuse under Octane.
+ * wildcard or empty Accept resolves to it. The resolver is request-explicit and
+ * holds no per-request state, so it is safe to reuse under Octane.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Jobs/ExportToDiskJob.php
+++ b/src/Jobs/ExportToDiskJob.php
@@ -169,8 +169,8 @@ final class ExportToDiskJob implements ShouldQueue
     }
 
     /**
-     * Dispatch the completion audit without rolling back a stored export when
-     * a listener fails.
+     * Dispatch the completion audit without rolling back a stored export when a
+     * listener fails.
      *
      * @param  \SineMacula\Exporter\Export\ExportAuditor  $auditor
      * @param  \SineMacula\Exporter\Events\ExportCompleted  $event

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -247,8 +247,8 @@ final class Column
      * given child (a resolver receives the child, otherwise the key or model
      * path is read off it) rather than the parent item, so each child yields
      * its own cell while the parent columns repeat. A null child - a parent
-     * with no children kept as a blank row - short-circuits to the
-     * null/default cell.
+     * with no children kept as a blank row - short-circuits to the null/default
+     * cell.
      *
      * @param  mixed  $child
      * @param  \Illuminate\Http\Request  $request

--- a/src/Schema/Contracts/CastRegistry.php
+++ b/src/Schema/Contracts/CastRegistry.php
@@ -7,8 +7,8 @@ namespace SineMacula\Exporter\Schema\Contracts;
 /**
  * Cast registry contract.
  *
- * The single registry mapping cast names to casters. Typed column casts and
- * the `cast()` escape hatch both resolve through here, giving one place to
+ * The single registry mapping cast names to casters. Typed column casts and the
+ * `cast()` escape hatch both resolve through here, giving one place to
  * register, override, and test casting behaviour.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>

--- a/src/Schema/EagerLoadPlan.php
+++ b/src/Schema/EagerLoadPlan.php
@@ -8,12 +8,12 @@ namespace SineMacula\Exporter\Schema;
  * Aggregate eager-load plan.
  *
  * The derived, source-agnostic description of the database aggregates a
- * schema's columns need: the relations to count and the relation/column
- * pairs to sum. A source that derives aggregates (a query, or an
- * Eloquent-backed collection) reads this to apply withCount()/withSum() so
- * each item carries the aggregate the column then folds into a cell. Plain
- * join() aggregates are ordinary eager-loads and travel through
- * withRelations(), not this plan. Immutable and stateless.
+ * schema's columns need: the relations to count and the relation/column pairs
+ * to sum. A source that derives aggregates (a query, or an Eloquent-backed
+ * collection) reads this to apply withCount()/withSum() so each item carries
+ * the aggregate the column then folds into a cell. Plain join() aggregates are
+ * ordinary eager-loads and travel through withRelations(), not this plan.
+ * Immutable and stateless.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Schema/Enums/CellType.php
+++ b/src/Schema/Enums/CellType.php
@@ -8,8 +8,8 @@ namespace SineMacula\Exporter\Schema\Enums;
  * Logical cell data type.
  *
  * Carried on every CellValue so a single schema drives both string-oriented
- * formats (CSV/TSV) and typed-cell formats (XLSX): a textual writer renders
- * the formatted string while a typed writer emits a native cell of this type.
+ * formats (CSV/TSV) and typed-cell formats (XLSX): a textual writer renders the
+ * formatted string while a typed writer emits a native cell of this type.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Schema/ExpandAxis.php
+++ b/src/Schema/ExpandAxis.php
@@ -7,12 +7,11 @@ namespace SineMacula\Exporter\Schema;
 /**
  * Resolved row-expansion axis.
  *
- * The validated, ready-to-stream form of a schema's expand policy: the
- * has-many relation whose children fan a parent item out into one row per
- * child, and whether a childless parent is dropped or kept as one row with
- * blank child cells. Exactly one axis exists per export (a single
- * ExpandPolicy relation), so no implicit cartesian product is possible.
- * Immutable and stateless.
+ * The validated, ready-to-stream form of a schema's expand policy: the has-many
+ * relation whose children fan a parent item out into one row per child, and
+ * whether a childless parent is dropped or kept as one row with blank child
+ * cells. Exactly one axis exists per export (a single ExpandPolicy relation),
+ * so no implicit cartesian product is possible. Immutable and stateless.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Schema/TabularSchema.php
+++ b/src/Schema/TabularSchema.php
@@ -11,9 +11,9 @@ use SineMacula\Exporter\Schema\Enums\Strictness;
  * Tabular schema.
  *
  * The request-aware declaration of a tabular representation: ordered columns,
- * eager-load hints, an optional single row-expansion axis, a filename hint,
- * and the row-level strictness mode. Authored as a dedicated sibling class so
- * the export shape stays separate from the API representation.
+ * eager-load hints, an optional single row-expansion axis, a filename hint, and
+ * the row-level strictness mode. Authored as a dedicated sibling class so the
+ * export shape stays separate from the API representation.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Schema/WarningCollector.php
+++ b/src/Schema/WarningCollector.php
@@ -7,12 +7,12 @@ namespace SineMacula\Exporter\Schema;
 /**
  * Lenient-mode warning bag.
  *
- * Streaming cannot emit a clean error mid-body, so the lenient strictness
- * mode skips or blanks the offending column or cell and records why here
- * instead of throwing. A caller that wants to surface or log degraded
- * output passes its own collector into the engine and reads it afterwards;
- * preflight mode never adds to it (it fails fast before any bytes). Created
- * per export, so it holds no cross-request state.
+ * Streaming cannot emit a clean error mid-body, so the lenient strictness mode
+ * skips or blanks the offending column or cell and records why here instead of
+ * throwing. A caller that wants to surface or log degraded output passes its
+ * own collector into the engine and reads it afterwards; preflight mode never
+ * adds to it (it fails fast before any bytes). Created per export, so it holds
+ * no cross-request state.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Sinks/DiskSink.php
+++ b/src/Sinks/DiskSink.php
@@ -12,9 +12,9 @@ use SineMacula\Exporter\Exceptions\SinkException;
  * Storage disk sink.
  *
  * Places a fully-written file onto a Laravel Storage disk at a given path.
- * Remote disks cannot be streamed to in place, so this is a non-seekable
- * sink: writers finalise locally and hand the file over via putFromFile,
- * which uploads it as a stream at constant memory.
+ * Remote disks cannot be streamed to in place, so this is a non-seekable sink:
+ * writers finalise locally and hand the file over via putFromFile, which
+ * uploads it as a stream at constant memory.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Sinks/StreamSink.php
+++ b/src/Sinks/StreamSink.php
@@ -11,8 +11,8 @@ use SineMacula\Exporter\Sinks\Concerns\WritesThroughStream;
  * Output stream sink.
  *
  * Streams the written bytes directly into a writable stream (php://output by
- * default) for immediate emission. Treated as a streamable sink so writers
- * push rows straight through it.
+ * default) for immediate emission. Treated as a streamable sink so writers push
+ * rows straight through it.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Sinks/StringSink.php
+++ b/src/Sinks/StringSink.php
@@ -11,8 +11,8 @@ use SineMacula\Exporter\Sinks\Concerns\WritesThroughStream;
  * String buffer sink.
  *
  * Buffers the written bytes in a seekable in-memory stream (spilling to a
- * temporary file beyond a memory threshold) so the full export can be read
- * back as a single string. Seekable, so writers stream into it directly.
+ * temporary file beyond a memory threshold) so the full export can be read back
+ * as a single string. Seekable, so writers stream into it directly.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Sinks/TempFileSink.php
+++ b/src/Sinks/TempFileSink.php
@@ -11,8 +11,8 @@ use SineMacula\Exporter\Exceptions\SinkException;
  * Temporary file sink.
  *
  * Lands a fully-written export in a local temporary file whose path the caller
- * can read back. A temp file backs formats that finalise on close (an XLSX is
- * a ZIP), so it is a non-seekable sink: writers finalise locally and hand the
+ * can read back. A temp file backs formats that finalise on close (an XLSX is a
+ * ZIP), so it is a non-seekable sink: writers finalise locally and hand the
  * file over via putFromFile.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>

--- a/src/Sources/QueryChunkSource.php
+++ b/src/Sources/QueryChunkSource.php
@@ -14,8 +14,8 @@ use SineMacula\Exporter\Schema\EagerLoadPlan;
  *
  * Normalises an Eloquent query into a keyset-paginated, lazy stream of its
  * models at constant memory. It uses lazyById() (stable under concurrent
- * inserts and self-ordering, unlike lazy()/cursor()) and force-selects the
- * key column so a constrained select() cannot abort the stream mid-flight.
+ * inserts and self-ordering, unlike lazy()/cursor()) and force-selects the key
+ * column so a constrained select() cannot abort the stream mid-flight.
  * Requested relations are applied to the query so each chunk eager-loads them,
  * and the schema's derived aggregates are applied as withCount()/withSum() so a
  * count or sum column carries its value without the caller wiring it by hand.

--- a/src/Writers/CellRenderer.php
+++ b/src/Writers/CellRenderer.php
@@ -9,13 +9,13 @@ use SineMacula\Exporter\Schema\CellValue;
 /**
  * Shared cell value coercion.
  *
- * The value-coercion semantics every tabular writer shares: a typed
- * CellValue is reduced to a native integer, float, boolean label, or string
- * the same way regardless of the target format, so the CSV/TSV text output
- * and the typed XLSX spreadsheet agree on what each cell holds. The writer
- * keeps ownership of the target type (a string field, a native numeric cell,
- * a date cell); this collaborator only decides the coerced value. It holds no
- * state and is safe to share under Octane.
+ * The value-coercion semantics every tabular writer shares: a typed CellValue
+ * is reduced to a native integer, float, boolean label, or string the same way
+ * regardless of the target format, so the CSV/TSV text output and the typed
+ * XLSX spreadsheet agree on what each cell holds. The writer keeps ownership of
+ * the target type (a string field, a native numeric cell, a date cell); this
+ * collaborator only decides the coerced value. It holds no state and is safe to
+ * share under Octane.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Writers/CountingWriter.php
+++ b/src/Writers/CountingWriter.php
@@ -14,12 +14,11 @@ use SineMacula\Exporter\Schema\TabularSchema;
  * Wraps any tabular writer and counts the data rows it emits, invoking a
  * callback with the running total as each row passes through. It lets the
  * streamed and queued export paths report progress and capture the final row
- * count for the audit event without the underlying writer or the engine
- * knowing anything about counting. The count is taken at the writer boundary so
- * it reflects the rows actually written (after row expansion), and the heading
- * row - emitted by the inner writer from the schema, not the row stream - is
- * not counted. The decorator adds no buffering, so constant memory is
- * preserved.
+ * count for the audit event without the underlying writer or the engine knowing
+ * anything about counting. The count is taken at the writer boundary so it
+ * reflects the rows actually written (after row expansion), and the heading row
+ * - emitted by the inner writer from the schema, not the row stream - is not
+ * counted. The decorator adds no buffering, so constant memory is preserved.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Writers/XlsxWriter.php
+++ b/src/Writers/XlsxWriter.php
@@ -171,9 +171,9 @@ final readonly class XlsxWriter implements Writer
     /**
      * Hand the finalised workbook to the sink.
      *
-     * A seekable sink receives the bytes through its stream; a
-     * non-seekable sink (an XLSX cannot stream into one in place)
-     * receives the finished file.
+     * A seekable sink receives the bytes through its stream; a non-seekable
+     * sink (an XLSX cannot stream into one in place) receives the finished
+     * file.
      *
      * @param  string  $path
      * @param  \SineMacula\Exporter\Contracts\Sink  $sink
@@ -303,11 +303,11 @@ final readonly class XlsxWriter implements Writer
     /**
      * Map a typed cell value to a native OpenSpout cell.
      *
-     * Numeric cells become numeric cells and dates become native date
-     * cells (so Excel can sort and filter them); booleans render to their
-     * configured label - so the spreadsheet reads the same as the CSV the
-     * schema also drives - and everything else becomes a string cell. A
-     * null becomes an empty cell.
+     * Numeric cells become numeric cells and dates become native date cells (so
+     * Excel can sort and filter them); booleans render to their configured
+     * label - so the spreadsheet reads the same as the CSV the schema also
+     * drives - and everything else becomes a string cell. A null becomes an
+     * empty cell.
      *
      * @param  \SineMacula\Exporter\Schema\CellValue  $cell
      * @param  \OpenSpout\Common\Entity\Style\Style  $dateStyle

--- a/tests/Integration/CustomFormatNegotiationTest.php
+++ b/tests/Integration/CustomFormatNegotiationTest.php
@@ -23,9 +23,9 @@ use Tests\Support\V3\Writers\ReportWriter;
  * The config('exporter.formats') extension seam is reachable and shared.
  *
  * A custom format declared in configuration is seeded into the single boot-time
- * media type registry, so it is negotiable over the Accept header and
- * reachable through the explicit Exporter::export() builder - both resolve the
- * same shared registry, so they agree on the available formats.
+ * media type registry, so it is negotiable over the Accept header and reachable
+ * through the explicit Exporter::export() builder - both resolve the same
+ * shared registry, so they agree on the available formats.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Integration/ExportHierarchicalNegotiationHttpTest.php
+++ b/tests/Integration/ExportHierarchicalNegotiationHttpTest.php
@@ -157,8 +157,8 @@ final class ExportHierarchicalNegotiationHttpTest extends ExporterTestCase
     }
 
     /**
-     * It exports a non-tabular resource as XML, JSON and NDJSON, but 406s
-     * for a tabular format the resource cannot describe.
+     * It exports a non-tabular resource as XML, JSON and NDJSON, but 406s for a
+     * tabular format the resource cannot describe.
      *
      * @return void
      */

--- a/tests/Integration/ExportToDiskJobTest.php
+++ b/tests/Integration/ExportToDiskJobTest.php
@@ -284,9 +284,9 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
     }
 
     /**
-     * It re-checks full-set authorization on the worker and rejects a
-     * forbidden actor before any file is stored - the shared authz check
-     * exercised through the queued front door.
+     * It re-checks full-set authorization on the worker and rejects a forbidden
+     * actor before any file is stored - the shared authz check exercised
+     * through the queued front door.
      *
      * @return void
      */

--- a/tests/Integration/ExportVisibilityTest.php
+++ b/tests/Integration/ExportVisibilityTest.php
@@ -21,8 +21,8 @@ use Tests\Support\V3\Schema\FlexibleSchema;
 /**
  * Tests for the column-level visibility gate, including the leak boundary.
  *
- * visible() is a build-time authorisation gate (fn(Request): bool, no item):
- * a column whose gate returns false is omitted entirely - from the heading row
+ * visible() is a build-time authorisation gate (fn(Request): bool, no item): a
+ * column whose gate returns false is omitted entirely - from the heading row
  * and from every data row. The security property is that a gated-out column
  * cannot leak its value through any other path, including the aggregate
  * eager-derivation that runs over the same query.

--- a/tests/Integration/OctaneStatelessnessTest.php
+++ b/tests/Integration/OctaneStatelessnessTest.php
@@ -26,8 +26,8 @@ use Tests\Support\V3\Schema\GatedSchema;
  * and cast registry inside it) are reused across exports whose request and auth
  * context differ, and each export reflects only its own request: a column the
  * request gates appears for the privileged request and is absent for the
- * unprivileged one, in either order, with no export leaking into the next.
- * No request is captured in a writer or driver; the request is passed in.
+ * unprivileged one, in either order, with no export leaking into the next. No
+ * request is captured in a writer or driver; the request is passed in.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Integration/SecurityTest.php
+++ b/tests/Integration/SecurityTest.php
@@ -28,10 +28,10 @@ use Tests\Support\V3\Schema\FlexibleSchema;
  * Consolidated security guarantees for the export pipeline.
  *
  * Pins the three security properties the release gate requires: CSV formula
- * injection is neutralised by default for every dangerous leading character
- * (= + - @ tab CR); a field the request gates out cannot leak through any
- * export path, neither the raw accessor nor the aggregate derivation that
- * rewrites the same query; and the streamed full-dataset query export re-checks
+ * injection is neutralised by default for every dangerous leading character (=
+ * + - @ tab CR); a field the request gates out cannot leak through any export
+ * path, neither the raw accessor nor the aggregate derivation that rewrites the
+ * same query; and the streamed full-dataset query export re-checks
  * authorization for the whole set before a byte is sent, not just the page.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>

--- a/tests/Support/V3/Models/Actor.php
+++ b/tests/Support/V3/Models/Actor.php
@@ -9,10 +9,10 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 /**
  * Authenticatable actor model for the queued-export authorization tests.
  *
- * The queued pipeline serializes an actor by id and class, then re-resolves
- * the real user on the worker to re-check full-set authorization through the
- * gate. This fixture is a minimal Authenticatable the queued tests attribute
- * an export to, so a forbidden actor can be rejected and an audited actor
+ * The queued pipeline serializes an actor by id and class, then re-resolves the
+ * real user on the worker to re-check full-set authorization through the gate.
+ * This fixture is a minimal Authenticatable the queued tests attribute an
+ * export to, so a forbidden actor can be rejected and an audited actor
  * identifier can be asserted on the completion event.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>

--- a/tests/Support/V3/Schema/ExplodingExportSchema.php
+++ b/tests/Support/V3/Schema/ExplodingExportSchema.php
@@ -11,11 +11,11 @@ use SineMacula\Exporter\Schema\TabularSchema;
 /**
  * Schema that passes preflight but throws while shaping a row.
  *
- * The columns are structurally valid, so the engine's preflight validation
- * lets the export begin and a staging file is opened; the resolver then throws
- * on the first data row, mid-stream, after bytes have started flowing. It
- * forces a genuine mid-stream failure so the queued job's cleanup - unlinking
- * the staging file and removing any partial disk file - can be asserted.
+ * The columns are structurally valid, so the engine's preflight validation lets
+ * the export begin and a staging file is opened; the resolver then throws on
+ * the first data row, mid-stream, after bytes have started flowing. It forces a
+ * genuine mid-stream failure so the queued job's cleanup - unlinking the
+ * staging file and removing any partial disk file - can be asserted.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Unit/EngineExpandRowsTest.php
+++ b/tests/Unit/EngineExpandRowsTest.php
@@ -23,10 +23,10 @@ use Tests\Support\V3\Schema\FlexibleSchema;
 /**
  * Tests for the engine's single row-expansion axis.
  *
- * A column marked expandRows() against a declared expand policy fans one
- * parent into one row per child, repeating the parent columns; a childless
- * parent keeps a single blank-child row by default or is dropped when
- * configured. Exactly one axis governs the fan-out (the schema exposes a single
+ * A column marked expandRows() against a declared expand policy fans one parent
+ * into one row per child, repeating the parent columns; a childless parent
+ * keeps a single blank-child row by default or is dropped when configured.
+ * Exactly one axis governs the fan-out (the schema exposes a single
  * ExpandPolicy), and a marked column with no declared axis is a configuration
  * error that preflight rejects before any bytes and lenient downgrades to a
  * warning.

--- a/tests/Unit/Export/ExportFilenameTest.php
+++ b/tests/Unit/Export/ExportFilenameTest.php
@@ -14,8 +14,8 @@ use SineMacula\Exporter\Http\MediaTypeRegistry;
 /**
  * Tests the download-naming helper.
  *
- * Resolves the media type for a format (tabular or hierarchical writer),
- * the extension-bearing download filename, and the Content-Disposition header.
+ * Resolves the media type for a format (tabular or hierarchical writer), the
+ * extension-bearing download filename, and the Content-Disposition header.
  * Filenames are sanitised the way makeDisposition() demands - path and percent
  * characters replaced, a pure-ASCII fallback always supplied - so a non-ASCII
  * name never throws.

--- a/tests/Unit/Sinks/SinkTest.php
+++ b/tests/Unit/Sinks/SinkTest.php
@@ -20,12 +20,11 @@ use Tests\Support\V3\ExporterTestCase;
  * Tests the five export sinks.
  *
  * A sink is the byte destination a writer streams into. The seekable sinks
- * (string buffer, raw stream, streamed response) expose a stream a writer
- * rows through; the non-seekable sinks (storage disk, temp file) take a
- * finalised file via putFromFile, the path an XLSX-style finalise-on-close
- * format needs. These tests exercise each sink's contract directly, including
- * the seekability flag, the finalise-then-upload path and the open-failure
- * guards.
+ * (string buffer, raw stream, streamed response) expose a stream a writer rows
+ * through; the non-seekable sinks (storage disk, temp file) take a finalised
+ * file via putFromFile, the path an XLSX-style finalise-on-close format needs.
+ * These tests exercise each sink's contract directly, including the seekability
+ * flag, the finalise-then-upload path and the open-failure guards.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Unit/Sources/ConnectionAwareSourceTest.php
+++ b/tests/Unit/Sources/ConnectionAwareSourceTest.php
@@ -15,8 +15,8 @@ use Tests\Support\V3\ArraySource;
  * Tests the connection-aware source decorator.
  *
  * The decorator streams its wrapped source until an abort signal reports the
- * client has disconnected, then stops cleanly, so a streamed export abandons
- * an expensive query the moment the browser goes away. It is transparent
+ * client has disconnected, then stops cleanly, so a streamed export abandons an
+ * expensive query the moment the browser goes away. It is transparent
  * otherwise: eager-load hints and, where supported, the aggregate plan are
  * forwarded to the wrapped source. These tests drive it with a stub abort
  * signal so the disconnect is deterministic rather than reliant on a real

--- a/tests/Unit/Writers/CsvWriterTest.php
+++ b/tests/Unit/Writers/CsvWriterTest.php
@@ -248,8 +248,8 @@ final class CsvWriterTest extends TestCase
     }
 
     /**
-     * It applies RFC-4180 quote doubling - leaving a backslash field
-     * unenclosed - rather than the league default backslash escape.
+     * It applies RFC-4180 quote doubling - leaving a backslash field unenclosed
+     * - rather than the league default backslash escape.
      *
      * @return void
      */


### PR DESCRIPTION
## Summary

- Reflow PHPDoc prose paragraphs so wrapped lines maximise the 80-character budget, including the leading docblock prefix.
- Leave tags, type annotations, property annotations, lists, and code-like lines unchanged.
- Cover tracked PHP files across `src`, benchmarks, and tests.

## Follow-up Audits

- Checked all `@param` and `@return` docblock tags for wrapped continuations: none found.
- Tried adding a blank line before the closing parenthesis on promoted-property constructors, but `qlty fmt` / php-cs-fixer removes those blank lines. No constructor formatting change is retained in the PR.

## Validation

- Independent subagent audit of `src`: no remaining under-wrapped prose paragraphs.
- Independent subagent audit outside `src`: no remaining under-wrapped prose paragraphs.
- Automated whole-repo audit: `TOTAL 0 affected prose paragraph(s) in 0 file(s).`
- `composer check`
- `composer test`
