### PR TITLE
fix: harden release export streaming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Contributions are welcome via GitHub pull requests. This guide covers the expect
 
 - PHP 8.3+
 - Composer 2
+- Qlty CLI on your `PATH` for `composer check`, `composer format`, and `composer smells`
 
 ## Getting Started
 

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "php": "^8.3",
         "ext-dom": "*",
         "ext-simplexml": "*",
-        "illuminate/http": "^12.0",
-        "illuminate/support": "^12.0",
+        "ext-xmlwriter": "*",
+        "laravel/framework": "^12.0",
         "league/csv": "^9.16"
     },
     "require-dev": {

--- a/config/exporter.php
+++ b/config/exporter.php
@@ -95,7 +95,7 @@ return [
     |
     | Each entry may be a SineMacula\Exporter\Http\ExportFormat instance, a
     | callable returning one, or the class name of a binding that resolves to a
-    | SineMacula\Exporter\Contracts\Format through the container. Because a
+    | SineMacula\Exporter\Http\ExportFormat through the container. Because a
     | tabular format carries a writer factory (a closure), register such formats
     | from a service provider rather than relying on `config:cache`. The
     | registry is built once at boot and never mutated per request, so it is

--- a/src/Exceptions/RowLimitExceeded.php
+++ b/src/Exceptions/RowLimitExceeded.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace SineMacula\Exporter\Exceptions;
 
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
 /**
  * Row limit exceeded exception.
  *
@@ -14,7 +16,7 @@ namespace SineMacula\Exporter\Exceptions;
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
-final class RowLimitExceeded extends \RuntimeException
+final class RowLimitExceeded extends HttpException
 {
     /**
      * Create an exception for an export whose row count exceeds the cap.
@@ -25,6 +27,6 @@ final class RowLimitExceeded extends \RuntimeException
      */
     public static function forCount(int $count, int $limit): self
     {
-        return new self("The export of [{$count}] rows exceeds the configured cap of [{$limit}]. Call unlimited() to lift it.");
+        return new self(413, "The export of [{$count}] rows exceeds the configured cap of [{$limit}]. Call unlimited() to lift it.");
     }
 }

--- a/src/Export/ExportAuditor.php
+++ b/src/Export/ExportAuditor.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace SineMacula\Exporter\Export;
 
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
@@ -38,15 +39,19 @@ final readonly class ExportAuditor
     /**
      * Re-check authorization for the full dataset, throwing when denied.
      *
-     * @param  \Closure(): void|null  $callback
+     * @param  \Closure(): mixed|null  $callback
      * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $actor
      * @param  string|null  $ability
      * @param  mixed  $arguments
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function authorize(?\Closure $callback = null, ?Authenticatable $actor = null, ?string $ability = null, mixed $arguments = []): void
     {
-        $callback?->__invoke();
+        if ($callback?->__invoke() === false) {
+            throw new AuthorizationException;
+        }
 
         if ($ability === null) {
             return;

--- a/src/ExportBuilder.php
+++ b/src/ExportBuilder.php
@@ -28,6 +28,7 @@ use SineMacula\Exporter\Sinks\DiskSink;
 use SineMacula\Exporter\Sinks\StreamedResponseSink;
 use SineMacula\Exporter\Sinks\StreamSink;
 use SineMacula\Exporter\Sinks\StringSink;
+use SineMacula\Exporter\Sources\QueryChunkSource;
 use SineMacula\Exporter\Sources\SourceFactory;
 use SineMacula\Exporter\Testing\ExporterFake;
 use SineMacula\Exporter\Writers\CountingWriter;
@@ -282,6 +283,12 @@ final class ExportBuilder
      */
     private function streamedResponse(string $filename): StreamedResponse
     {
+        $source = SourceFactory::for($this->subject, $this->chunkSize);
+
+        if ($source instanceof QueryChunkSource) {
+            $source->guardKeysetOrdering();
+        }
+
         $names   = new ExportFilename($this->registry, $this->format);
         $headers = [
             'Content-Type'        => $names->mediaType() . '; charset=UTF-8',

--- a/src/Http/ExportNegotiator.php
+++ b/src/Http/ExportNegotiator.php
@@ -288,21 +288,32 @@ final readonly class ExportNegotiator
      * @param  \SineMacula\Exporter\Contracts\HierarchicalWriter  $writer
      * @param  string  $format
      * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(int): void|null  $onComplete
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
-    public function streamHierarchical(Source $source, \Closure $toArray, HierarchicalWriter $writer, string $format, Request $request): StreamedResponse
-    {
+    public function streamHierarchical(
+        Source $source,
+        \Closure $toArray,
+        HierarchicalWriter $writer,
+        string $format,
+        Request $request,
+        ?\Closure $onComplete = null,
+    ): StreamedResponse {
         $sink = new StreamedResponseSink;
 
         return $sink->toResponse(
-            function (Sink $stream) use ($source, $toArray, $writer, $format, $request): void {
+            function (Sink $stream) use ($source, $toArray, $writer, $format, $request, $onComplete): void {
                 $rows = 0;
 
                 try {
                     $writer->write($this->countedRows($this->resolveRows($this->abortAware($source), $toArray), $rows), $stream);
                 } catch (\Throwable $exception) {
                     $this->failStream($format, $rows, $request, $exception);
+
+                    return;
                 }
+
+                $onComplete?->__invoke($rows);
             },
             200,
             [
@@ -322,7 +333,7 @@ final readonly class ExportNegotiator
      * @param  \Illuminate\Http\Request  $request
      * @return \SineMacula\Exporter\Contracts\HierarchicalWriter|null
      */
-    private function hierarchicalWriterFor(string $format, Request $request): ?HierarchicalWriter
+    public function hierarchicalWriterFor(string $format, Request $request): ?HierarchicalWriter
     {
         if ($format === $this->registry->defaultFormat() && !$this->resolver->isExplicitFormat($request)) {
             return null;

--- a/src/ResourceExport.php
+++ b/src/ResourceExport.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
+use SineMacula\Exporter\Contracts\HierarchicalWriter;
 use SineMacula\Exporter\Contracts\ProvidesTabularExport;
 use SineMacula\Exporter\Events\ExportCompleted;
 use SineMacula\Exporter\Exceptions\NoTabularRepresentation;
@@ -64,7 +65,7 @@ final class ResourceExport
     /** @var int The keyset chunk size used while streaming the full set */
     private int $chunkSize;
 
-    /** @var (\Closure(\Illuminate\Http\Request, \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>): void)|null The full-set authorization re-check */
+    /** @var (\Closure(\Illuminate\Http\Request, \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>): mixed)|null The full-set authorization re-check */
     private ?\Closure $authorization = null;
 
     /** @var (\Closure(array<string, mixed>): void)|null The audit hook fired around a streamed export */
@@ -159,7 +160,7 @@ final class ResourceExport
     /**
      * Register the full-set authorization re-check for the export path.
      *
-     * @param  \Closure(\Illuminate\Http\Request, \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>): void  $callback
+     * @param  \Closure(\Illuminate\Http\Request, \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>): mixed  $callback
      * @return $this
      */
     public function authorizeUsing(\Closure $callback): static
@@ -217,9 +218,15 @@ final class ResourceExport
 
         $format = $negotiator->resolve($request);
 
-        return $negotiator->isTabular($format)
-            ? $this->streamResponse($negotiator, $format, $request)
-            : $this->jsonResponse($request);
+        if ($negotiator->isTabular($format)) {
+            return $this->streamResponse($negotiator, $format, $request);
+        }
+
+        $writer = $negotiator->hierarchicalWriterFor($format, $request);
+
+        return $writer === null
+            ? $this->jsonResponse($request)
+            : $this->streamHierarchicalResponse($negotiator, $writer, $format, $request);
     }
 
     /**
@@ -273,14 +280,52 @@ final class ResourceExport
         $this->enforceRowCap();
 
         $schema = $this->schema($request);
+        $source = new QueryChunkSource($this->query, $this->chunkSize);
+        $source->guardKeysetOrdering();
 
         return $negotiator->streamExport(
-            new QueryChunkSource($this->query, $this->chunkSize),
+            $source,
             $schema,
             $format,
             $request,
             function (int $rows) use ($auditor, $request, $schema, $format): void {
-                $this->complete($auditor, $request, $schema, $format, $rows);
+                $this->complete($auditor, $request, $schema->filename(), $format, $rows);
+            },
+        );
+    }
+
+    /**
+     * Build the streamed full-dataset hierarchical response.
+     *
+     * @param  \SineMacula\Exporter\Http\ExportNegotiator  $negotiator
+     * @param  \SineMacula\Exporter\Contracts\HierarchicalWriter  $writer
+     * @param  string  $format
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     *
+     * @throws \LogicException
+     * @throws \SineMacula\Exporter\Exceptions\RowLimitExceeded
+     */
+    private function streamHierarchicalResponse(ExportNegotiator $negotiator, HierarchicalWriter $writer, string $format, Request $request): Response
+    {
+        $auditor  = new ExportAuditor;
+        $resource = $this->resourceClass;
+
+        $this->guardAuthorizationDecision();
+        $this->authorizeFullSet($auditor, $request);
+        $this->enforceRowCap();
+
+        $source = new QueryChunkSource($this->query, $this->chunkSize);
+        $source->guardKeysetOrdering();
+
+        return $negotiator->streamHierarchical(
+            $source,
+            static fn (mixed $item): array => (new $resource($item))->resolve($request),
+            $writer,
+            $format,
+            $request,
+            function (int $rows) use ($auditor, $request, $format): void {
+                $this->complete($auditor, $request, null, $format, $rows);
             },
         );
     }
@@ -345,9 +390,7 @@ final class ResourceExport
         $authorization = $this->authorization;
 
         $auditor->authorize(
-            callback: $authorization === null ? null : function () use ($authorization, $request): void {
-                $authorization($request, $this->query);
-            },
+            callback: $authorization === null ? null : fn (): mixed => $authorization($request, $this->query),
         );
     }
 
@@ -388,19 +431,19 @@ final class ResourceExport
      *
      * @param  \SineMacula\Exporter\Export\ExportAuditor  $auditor
      * @param  \Illuminate\Http\Request  $request
-     * @param  \SineMacula\Exporter\Schema\TabularSchema  $schema
+     * @param  string|null  $filename
      * @param  string  $format
      * @param  int  $rows
      * @return void
      */
-    private function complete(ExportAuditor $auditor, Request $request, TabularSchema $schema, string $format, int $rows): void
+    private function complete(ExportAuditor $auditor, Request $request, ?string $filename, string $format, int $rows): void
     {
         $actorId = $this->actorId($request);
 
         $auditor->completed(new ExportCompleted(
             $actorId,
             $rows,
-            $schema->filename(),
+            $filename,
             $format,
             CarbonImmutable::now(),
         ));
@@ -412,7 +455,7 @@ final class ResourceExport
         ($this->audit)([
             'actor_id'  => $actorId,
             'row_count' => $rows,
-            'filename'  => $schema->filename(),
+            'filename'  => $filename,
             'format'    => $format,
         ]);
     }

--- a/src/Sources/QueryChunkSource.php
+++ b/src/Sources/QueryChunkSource.php
@@ -55,6 +55,8 @@ final class QueryChunkSource implements DerivesAggregates, Source
     #[\Override]
     public function rows(): iterable
     {
+        $direction = $this->keysetDirection();
+
         $this->forceSelectKey();
 
         if ($this->with !== []) {
@@ -63,9 +65,25 @@ final class QueryChunkSource implements DerivesAggregates, Source
 
         $this->applyAggregates();
 
-        foreach ($this->query->lazyById($this->chunkSize) as $item) {
+        $rows = $direction === 'desc'
+            ? $this->query->lazyByIdDesc($this->chunkSize)
+            : $this->query->lazyById($this->chunkSize);
+
+        foreach ($rows as $item) {
             yield $item;
         }
+    }
+
+    /**
+     * Assert that the query can be streamed safely before bytes are committed.
+     *
+     * @return void
+     *
+     * @throws \LogicException
+     */
+    public function guardKeysetOrdering(): void
+    {
+        $this->keysetDirection();
     }
 
     /**
@@ -151,5 +169,109 @@ final class QueryChunkSource implements DerivesAggregates, Source
         }
 
         $this->query->getQuery()->addSelect($qualified);
+    }
+
+    /**
+     * Resolve whether the query can be streamed safely by primary key order.
+     *
+     * Eloquent's lazyById() appends a keyset predicate but does not make a
+     * non-key ORDER BY stable across chunks. Rejecting those orders is safer
+     * than silently duplicating or skipping rows in a full export.
+     *
+     * @return 'asc'|'desc'
+     *
+     * @throws \LogicException
+     */
+    private function keysetDirection(): string
+    {
+        $orders = $this->keysetOrders();
+
+        if ($orders === []) {
+            return 'asc';
+        }
+
+        $key        = $this->query->getModel()->getKeyName();
+        $qualified  = $this->query->qualifyColumn($key);
+        $directions = [];
+
+        foreach ($orders as $order) {
+            $this->guardKeysetOrder($order, $key, $qualified);
+            $directions[] = $this->orderDirection($order);
+        }
+
+        $unique = array_values(array_unique($directions));
+
+        if (count($unique) > 1) {
+            throw new \LogicException("QueryChunkSource cannot stream conflicting keyset directions for [{$key}].");
+        }
+
+        return $unique[0];
+    }
+
+    /**
+     * Read the query's configured order clauses.
+     *
+     * @return list<array{column: object|string|null, direction: string}>
+     */
+    private function keysetOrders(): array
+    {
+        $orders = array_merge(
+            $this->query->getQuery()->orders      ?? [],
+            $this->query->getQuery()->unionOrders ?? [],
+        );
+
+        $normalised = [];
+
+        foreach ($orders as $order) {
+            if (!is_array($order)) {
+                continue;
+            }
+
+            $column    = $order['column']    ?? null;
+            $direction = $order['direction'] ?? 'asc';
+
+            $normalised[] = [
+                'column'    => is_string($column) || is_object($column) ? $column : null,
+                'direction' => is_string($direction) ? $direction : 'asc',
+            ];
+        }
+
+        return $normalised;
+    }
+
+    /**
+     * Guard that an order clause sorts only by the model key.
+     *
+     * @param  array{column: object|string|null, direction: string}  $order
+     * @param  string  $key
+     * @param  string  $qualified
+     * @return void
+     *
+     * @throws \LogicException
+     */
+    private function guardKeysetOrder(array $order, string $key, string $qualified): void
+    {
+        $column = $order['column'] ?? null;
+
+        if ($column === $key || $column === $qualified) {
+            return;
+        }
+
+        $label = is_string($column) ? $column : 'raw expression';
+
+        throw new \LogicException("QueryChunkSource can only stream keyset-safe ordering by [{$key}]; [{$label}] would duplicate or skip rows across chunks.");
+    }
+
+    /**
+     * Resolve the normalised direction for an order clause.
+     *
+     * @param  array{column: object|string|null, direction: string}  $order
+     * @return 'asc'|'desc'
+     */
+    private function orderDirection(array $order): string
+    {
+        return strtolower($order['direction']) === 'desc'
+            ? 'desc'
+            : 'asc';
     }
 }

--- a/tests/Integration/ExportBuilderTest.php
+++ b/tests/Integration/ExportBuilderTest.php
@@ -100,6 +100,23 @@ final class ExportBuilderTest extends ExporterTestCase
     }
 
     /**
+     * It rejects non-key ordered query downloads before building a response.
+     *
+     * @return void
+     */
+    public function testDownloadRejectsNonKeyOrderedQueryBeforeStreaming(): void
+    {
+        $this->seedUsers(5);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('score');
+
+        Exporter::query(User::query()->orderBy('score', 'desc'), UserResource::class) // @phpstan-ignore staticMethod.dynamicCall
+            ->format('csv')
+            ->download();
+    }
+
+    /**
      * It writes the export to a storage disk and returns the destination path.
      *
      * @return void

--- a/tests/Integration/QueryChunkSourceTest.php
+++ b/tests/Integration/QueryChunkSourceTest.php
@@ -45,6 +45,45 @@ final class QueryChunkSourceTest extends ExporterTestCase
     }
 
     /**
+     * It streams every model in descending keyset order when requested.
+     *
+     * @return void
+     */
+    public function testStreamsEveryModelInDescendingKeysetOrder(): void
+    {
+        $this->seedUsers(5);
+
+        $source = new QueryChunkSource(User::query()->orderBy('id', 'desc'), chunkSize: 2); // @phpstan-ignore staticMethod.dynamicCall
+
+        $ids = [];
+
+        foreach ($source->rows() as $user) {
+            self::assertInstanceOf(User::class, $user);
+            $ids[] = $user->id;
+        }
+
+        self::assertSame([5, 4, 3, 2, 1], $ids);
+    }
+
+    /**
+     * It rejects non-key ordering because lazy keyset pagination cannot
+     * preserve it safely.
+     *
+     * @return void
+     */
+    public function testRejectsNonKeyOrdering(): void
+    {
+        $this->seedUsers(5);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('score');
+
+        $source = new QueryChunkSource(User::query()->orderBy('score', 'desc'), chunkSize: 2); // @phpstan-ignore staticMethod.dynamicCall
+
+        iterator_to_array($source->rows(), false);
+    }
+
+    /**
      * It force-selects the key column so a constrained select cannot abort the
      * keyset stream mid-flight.
      *

--- a/tests/Integration/ResourceExportTest.php
+++ b/tests/Integration/ResourceExportTest.php
@@ -79,6 +79,23 @@ final class ResourceExportTest extends ExporterTestCase
     }
 
     /**
+     * It rejects non-key ordering before building a streamed response.
+     *
+     * @return void
+     */
+    public function testExportRequestRejectsNonKeyOrderingBeforeStreaming(): void
+    {
+        $this->seedUsers(5);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('score');
+
+        ResourceExport::forQuery(User::query()->orderBy('score', 'desc'), UserResource::class) // @phpstan-ignore staticMethod.dynamicCall
+            ->withoutAuthorization()
+            ->paginatedJsonOrStreamedExport($this->exportRequest());
+    }
+
+    /**
      * It enforces the row cap before any bytes are streamed.
      *
      * @return void
@@ -87,12 +104,18 @@ final class ResourceExportTest extends ExporterTestCase
     {
         $this->seedUsers(5);
 
-        $this->expectException(RowLimitExceeded::class);
+        try {
+            ResourceExport::forQuery(User::query(), UserResource::class)
+                ->maxRows(2)
+                ->withoutAuthorization()
+                ->paginatedJsonOrStreamedExport($this->exportRequest());
+        } catch (RowLimitExceeded $exception) {
+            self::assertSame(413, $exception->getStatusCode());
 
-        ResourceExport::forQuery(User::query(), UserResource::class)
-            ->maxRows(2)
-            ->withoutAuthorization()
-            ->paginatedJsonOrStreamedExport($this->exportRequest());
+            return;
+        }
+
+        self::fail('The row cap should reject oversized exports before streaming.');
     }
 
     /**
@@ -192,6 +215,35 @@ final class ResourceExportTest extends ExporterTestCase
             ->unlimited()
             ->withoutAuthorization()
             ->paginatedJsonOrStreamedExport($this->exportRequest());
+    }
+
+    /**
+     * It streams explicit hierarchical export requests over the full dataset.
+     *
+     * @return void
+     */
+    public function testHierarchicalExportRequestStreamsTheFullDataset(): void
+    {
+        Event::fake([ExportCompleted::class]);
+
+        $this->seedUsers(25);
+
+        $response = ResourceExport::forQuery(User::query()->orderBy('id'), PlainUserResource::class) // @phpstan-ignore staticMethod.dynamicCall
+            ->perPage(10)
+            ->chunk(10)
+            ->withoutAuthorization()
+            ->paginatedJsonOrStreamedExport($this->ndjsonRequest());
+
+        self::assertInstanceOf(StreamedResponse::class, $response);
+
+        $lines = array_values(array_filter(explode("\n", $this->streamToString($response)), static fn (string $line): bool => $line !== ''));
+
+        self::assertCount(25, $lines);
+        self::assertSame(['id' => 1, 'name' => 'User 1'], json_decode($lines[0], true));
+
+        Event::assertDispatched(ExportCompleted::class, static fn (ExportCompleted $event): bool => $event->rowCount === 25
+            && $event->filename                                                                                      === null
+            && $event->format                                                                                        === 'ndjson');
     }
 
     /**
@@ -332,6 +384,22 @@ final class ResourceExportTest extends ExporterTestCase
     }
 
     /**
+     * It rejects a forbidden actor when authorizeUsing() returns false.
+     *
+     * @return void
+     */
+    public function testAuthorizeUsingRejectsFalse(): void
+    {
+        $this->seedUsers(3);
+
+        $this->expectException(AuthorizationException::class);
+
+        ResourceExport::forQuery(User::query(), UserResource::class)
+            ->authorizeUsing(static fn (Request $request, Builder $query): bool => false)
+            ->paginatedJsonOrStreamedExport($this->exportRequest());
+    }
+
+    /**
      * It dispatches the pinned ExportCompleted event with an integer actor id.
      *
      * @return void
@@ -419,6 +487,16 @@ final class ResourceExportTest extends ExporterTestCase
     private function exportRequest(): Request
     {
         return Request::create('/users', 'GET', server: ['HTTP_ACCEPT' => 'text/csv']);
+    }
+
+    /**
+     * Build an NDJSON-preferring export request.
+     *
+     * @return \Illuminate\Http\Request
+     */
+    private function ndjsonRequest(): Request
+    {
+        return Request::create('/users', 'GET', server: ['HTTP_ACCEPT' => 'application/x-ndjson']);
     }
 
     /**


### PR DESCRIPTION
## Summary

- enforce boolean `authorizeUsing()` denials
- stream full-query hierarchical exports through the same authorization, row-cap, and audit path
- reject non-key query ordering before streamed responses can commit headers
- return row-cap failures as HTTP 413 exceptions
- tighten runtime requirements and custom-format docs

## Validation

- `composer validate --strict`
- `composer check`
- `composer test`
- `composer test:coverage`
- `composer test:mutation`
- `composer bench:smoke`
- `git diff --check origin/3.x`

## Notes

- `composer audit` reports no security advisories, but still exits 2 for abandoned dev-only `doctrine/annotations` via PHPBench.
- Integration tests remain flat; subagent review found a directory split would be churn for this release.
