### PR TITLE
style: maximise docblock wrapping

### DIFF
--- a/src/ExportBuilder.php
+++ b/src/ExportBuilder.php
@@ -391,10 +391,10 @@ final class ExportBuilder // phpcs:ignore SineMacula.Metrics.MaxMethodCount.TooM
     /**
      * Validate a tabular schema before a streamed response commits its 200.
      *
-     * The writer and media type are already resolved (and a missing one
-     * already thrown) while building the response headers; this adds the
-     * schema check so a preflight-strict schema fault throws here - before any
-     * bytes are streamed, rather than mid-body into an already-committed 200.
+     * The writer and media type are already resolved (and a missing one already
+     * thrown) while building the response headers; this adds the schema check
+     * so a preflight-strict schema fault throws here - before any bytes are
+     * streamed, rather than mid-body into an already-committed 200.
      *
      * @return void
      *

--- a/src/Writers/Concerns/WritesBytes.php
+++ b/src/Writers/Concerns/WritesBytes.php
@@ -11,9 +11,9 @@ use SineMacula\Exporter\Exceptions\SinkException;
  *
  * The shared checked-write step behind the streaming JSON, NDJSON and XML
  * writers. A bare fwrite() returns false on a failed write (a full disk, a
- * closed pipe) without raising, so a streamed export would otherwise drop
- * bytes and still report success. Routing each data-path write through here
- * turns that silent truncation into a SinkException the writer propagates.
+ * closed pipe) without raising, so a streamed export would otherwise drop bytes
+ * and still report success. Routing each data-path write through here turns
+ * that silent truncation into a SinkException the writer propagates.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.


### PR DESCRIPTION
## Summary
- Maximises wrapping in two prose docblocks without exceeding the 80-character PHPCS limit.
- Re-ran the custom docblock audits for prose wrapping, annotation wrapping, and broken words.

## Validation
- composer validate --strict
- composer format -- --all
- composer check -- --all
- composer smells -- --all
- composer test
- composer test:coverage
- composer test:mutation
- composer test:mutation:full
- composer bench:ci