### PR TITLE
fix(v3): resolve phpstan findings on the negotiation fallback schema

### DIFF
--- a/src/Http/Middleware/NegotiateExports.php
+++ b/src/Http/Middleware/NegotiateExports.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\LazyCollection;
 use SineMacula\Exporter\Http\ExportNegotiator;
 use SineMacula\Exporter\Schema\Column;
+use SineMacula\Exporter\Schema\DecodedPayloadSchema;
 use SineMacula\Exporter\Schema\TabularSchema;
 use SineMacula\Exporter\Sources\LazyCollectionSource;
 use Symfony\Component\HttpFoundation\Response;
@@ -150,39 +151,7 @@ final readonly class NegotiateExports
             );
         }
 
-        return new class ($request, $columns) extends TabularSchema {
-            /** @var list<\SineMacula\Exporter\Schema\Column> The ad-hoc columns mirroring the decoded payload */
-            private readonly array $columns;
-
-            /**
-             * Create the ad-hoc legacy schema.
-             *
-             * @param  \Illuminate\Http\Request  $request
-             * @param  list<\SineMacula\Exporter\Schema\Column>  $columns
-             */
-            public function __construct(
-
-                // The request the export is built for.
-                Request $request,
-
-                array $columns,
-            ) {
-                parent::__construct($request);
-
-                $this->columns = $columns;
-            }
-
-            /**
-             * Get the ad-hoc columns mirroring the decoded payload.
-             *
-             * @return list<\SineMacula\Exporter\Schema\Column>
-             */
-            #[\Override]
-            public function columns(): array
-            {
-                return $this->columns;
-            }
-        };
+        return new DecodedPayloadSchema($request, $columns);
     }
 
     /**

--- a/src/Schema/DecodedPayloadSchema.php
+++ b/src/Schema/DecodedPayloadSchema.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace SineMacula\Exporter\Schema;
+
+use Illuminate\Http\Request;
+
+/**
+ * Ad-hoc tabular schema mirroring a decoded payload's keys.
+ *
+ * Built by the negotiation middleware's raw-array fallback so a response that
+ * is not backed by an API resource can still be streamed: each column reads its
+ * value straight from the decoded row and renders a scalar as-is, JSON-encoding
+ * any nested value. Kept internal to that fallback.
+ *
+ * @author      Ben Carey <bdmc@sinemacula.co.uk>
+ * @copyright   2026 Sine Macula Limited.
+ *
+ * @internal
+ */
+final class DecodedPayloadSchema extends TabularSchema
+{
+    /**
+     * Create the ad-hoc schema.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  list<\SineMacula\Exporter\Schema\Column>  $columns
+     */
+    public function __construct(
+
+        // The request the export is built for.
+        Request $request,
+
+        /** @var list<\SineMacula\Exporter\Schema\Column> The ad-hoc columns mirroring the decoded payload */
+        private readonly array $columns,
+    ) {
+        parent::__construct($request);
+    }
+
+    /**
+     * Get the ad-hoc columns mirroring the decoded payload.
+     *
+     * @return list<\SineMacula\Exporter\Schema\Column>
+     */
+    #[\Override]
+    public function columns(): array
+    {
+        return $this->columns;
+    }
+}

--- a/tests/Integration/Http/NegotiateExportsMiddlewareTest.php
+++ b/tests/Integration/Http/NegotiateExportsMiddlewareTest.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use SineMacula\Exporter\Http\Middleware\NegotiateExports;
+use SineMacula\Exporter\Schema\DecodedPayloadSchema;
 use Tests\Support\ExporterTestCase;
 
 /**
@@ -25,6 +26,7 @@ use Tests\Support\ExporterTestCase;
  * @internal
  */
 #[CoversClass(NegotiateExports::class)]
+#[CoversClass(DecodedPayloadSchema::class)]
 final class NegotiateExportsMiddlewareTest extends ExporterTestCase
 {
     /**


### PR DESCRIPTION
Resolves the 3 blocking Qlty (phpstan) findings on #39 (the `3.x` → `master` merge). The too-many-parameters structure findings are intentionally allowed and left as-is.

### Cause
The negotiation middleware built its raw-array fallback schema as an **anonymous** `TabularSchema`. phpstan does not reliably read the inline `@var`/`@param` PHPDoc on anonymous-class members, so a fresh analysis (the full `3.x` tree diffed against `master`) reported:

- `$columns` property has no iterable value type
- `__construct()` parameter `$columns` has no iterable value type
- `columns()` should return `list<Column>` but returns `array`

(Local `qlty check --all` passed only because of a stale phpstan tool sandbox; reproduced after clearing `~/.qlty/cache/tools/phpstan`.)

### Fix
Extracted the anonymous class to a small `@internal` named `DecodedPayloadSchema` — named classes resolve their member PHPDoc reliably, so the `list<Column>` types are honoured. No behaviour change. Added `#[CoversClass(DecodedPayloadSchema::class)]` to keep coverage attribution at 100%.

### Gates
- `qlty check --all --no-cache` (fresh phpstan): clean
- 495 tests pass, 100% coverage (67/67 classes, 386/386 methods, 1626/1626 lines)
- Mutation: 92% covered MSI (gate 90)