### PR TITLE
ci: scope the PR mutation gate to the diff and run it in parallel

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -38,10 +38,10 @@ defaults:
 jobs:
 
     # ==========================================================================
-    # JOB: SCOPED MUTATION GATE (PR + PUSH)
+    # JOB: SCOPED MUTATION GATE (PR)
     # ==========================================================================
     mutation:
-        if: ${{ github.event_name != 'schedule' }}
+        if: ${{ github.event_name == 'pull_request' }}
         name: Mutation / PHP 8.3
         runs-on: ubuntu-latest
 
@@ -50,11 +50,16 @@ jobs:
                 uses: actions/checkout@v5
                 with:
                     persist-credentials: false
+                    fetch-depth: 0
+
+            -   name: Fetch base branch for the diff
+                run: git fetch --no-tags origin master
 
             -   name: Setup PHP
                 uses: sinemacula/.github/.github/actions/setup-php@v1.1.1
                 with:
                     php-version: 8.3
+                    coverage: pcov
 
             -   name: Scoped mutation gate
                 run: composer test:mutation
@@ -78,6 +83,7 @@ jobs:
                 uses: sinemacula/.github/.github/actions/setup-php@v1.1.1
                 with:
                     php-version: 8.3
+                    coverage: pcov
 
             -   name: Full mutation suite
                 run: composer test:mutation:full

--- a/composer.json
+++ b/composer.json
@@ -72,10 +72,10 @@
             "@php vendor/bin/paratest --coverage-clover=clover.xml"
         ],
         "test:mutation": [
-            "@php vendor/bin/infection --configuration=infection.json5 --only-covering-test-cases --min-msi=90 --min-covered-msi=90"
+            "@php vendor/bin/infection --configuration=infection.json5 --only-covering-test-cases --threads=max --git-diff-lines --git-diff-base=origin/master --map-source-class-to-test --min-msi=90 --min-covered-msi=90"
         ],
         "test:mutation:full": [
-            "@php vendor/bin/infection --configuration=infection.full.json5 --only-covering-test-cases"
+            "@php vendor/bin/infection --configuration=infection.full.json5 --only-covering-test-cases --threads=max"
         ],
         "bench": [
             "@php vendor/bin/phpbench run benchmarks --config=phpbench.json --progress=plain --report=aggregate"


### PR DESCRIPTION
The PR mutation gate now mutates only the diff against `origin/master` and runs in parallel via `--threads=max`, cutting CI time on small changes. The full unscoped run is kept as the scheduled safety net.

- `test:mutation` gains `--threads=max --git-diff-lines --git-diff-base=origin/master --map-source-class-to-test` (thresholds unchanged).
- `test:mutation:full` gains `--threads=max`.
- Scoped mutation job now runs on pull_request only, fetches the base branch for the diff, and uses pcov coverage.