### PR TITLE
chore: ignore MSI gate when the scoped diff yields no mutations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
             "@php vendor/bin/paratest --coverage-clover=clover.xml"
         ],
         "test:mutation": [
-            "@php vendor/bin/infection --configuration=infection.json5 --only-covering-test-cases --threads=max --git-diff-lines --git-diff-base=origin/master --map-source-class-to-test --min-msi=90 --min-covered-msi=90"
+            "@php vendor/bin/infection --configuration=infection.json5 --only-covering-test-cases --threads=max --git-diff-lines --git-diff-base=origin/master --map-source-class-to-test --min-msi=90 --min-covered-msi=90 --ignore-msi-with-no-mutations"
         ],
         "test:mutation:full": [
             "@php vendor/bin/infection --configuration=infection.full.json5 --only-covering-test-cases --threads=max"


### PR DESCRIPTION
## Summary

Follow-up to the renovate bumps of `sinemacula/coding-standards` (v1.13 -> v1.17): ran the latest standards across the whole repo and hardened the scoped mutation gate.

### Standards run (no changes required)

- Verified the qlty tool sandboxes had already resolved `coding-standards` v1.17.0 and `coding-standards-laravel` v1.3.0 (both latest) - no sandbox clearing needed.
- `qlty check --all --no-cache`: clean. Confirmed this is not a false green by dropping a throwaway violating class, which surfaced 19 findings across phpcs (including the `SineMacula`/`SineMaculaLaravel` sniffs), phpstan, radarlint, and php-cs-fixer.
- `qlty fmt --all`: no diff.
- `qlty smells --all`: only the pre-existing constructor many-parameter findings (promoted-property value objects: events, specification, writers) - the known false-positive category; the smells checker itself has not changed.

So the codebase is already fully compliant with v1.17.0 - this PR contains **no style or functional changes**.

### Mutation gate

- Added `--ignore-msi-with-no-mutations` to `test:mutation` so style-only or non-source PRs (which generate zero mutants under `--git-diff-lines`) no longer trip the MSI thresholds.

## Verification

- `composer validate --strict`: valid
- `composer test`: 495 tests, 1297 assertions, all passing
- `composer test:mutation` on this branch: exits OK with nothing to mutate