### PR TITLE
feat: support Laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,13 +40,37 @@ jobs:
     # JOB: TESTS
     # ==========================================================================
     tests:
-        name: Test / PHP ${{ matrix.php }}
+        name: Test / PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel.label }}
         runs-on: ubuntu-latest
 
         strategy:
             fail-fast: false
             matrix:
-                php: [ 8.3, 8.4, 8.5 ]
+                include:
+                    -   php: 8.3
+                        laravel:
+                            constraint: ^12.0
+                            label: 12
+                    -   php: 8.3
+                        laravel:
+                            constraint: ^13.0
+                            label: 13
+                    -   php: 8.4
+                        laravel:
+                            constraint: ^12.0
+                            label: 12
+                    -   php: 8.4
+                        laravel:
+                            constraint: ^13.0
+                            label: 13
+                    -   php: 8.5
+                        laravel:
+                            constraint: ^12.0
+                            label: 12
+                    -   php: 8.5
+                        laravel:
+                            constraint: ^13.0
+                            label: 13
 
         steps:
             -   name: Checkout
@@ -59,6 +83,11 @@ jobs:
                 with:
                     php-version: ${{ matrix.php }}
 
+            -   name: Pin Laravel version
+                env:
+                    LARAVEL_CONSTRAINT: ${{ matrix.laravel.constraint }}
+                run: composer update --with="laravel/framework:${LARAVEL_CONSTRAINT}" --prefer-dist --no-interaction --no-progress
+
             -   name: PHPUnit
                 run: composer test:coverage
 
@@ -66,7 +95,7 @@ jobs:
                 run: composer bench:smoke
 
             -   name: Publish code coverage
-                if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.php == '8.3' }}
+                if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.php == '8.3' && matrix.laravel.label == '13' }}
                 uses: qltysh/qlty-action/coverage@v2
                 with:
                     oidc: true

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^8.3",
         "ext-filter": "*",
         "ext-xmlwriter": "*",
-        "laravel/framework": "^12.0",
+        "laravel/framework": "^12.0 || ^13.0",
         "league/csv": "^9.16"
     },
     "require-dev": {
@@ -28,7 +28,7 @@
         "friendsofphp/php-cs-fixer": "^3.94",
         "infection/infection": "^0.33.2",
         "openspout/openspout": "^4.0",
-        "orchestra/testbench": "^10.0",
+        "orchestra/testbench": "^10.0 || ^11.0",
         "phpbench/phpbench": "^1.6.1",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpdoc-parser": "^2.3",


### PR DESCRIPTION
Widens laravel/framework to ^12.0 || ^13.0 and orchestra/testbench to ^10.0 || ^11.0, and replaces the PHP-only test matrix with the org's canonical Laravel version matrix (PHP 8.3/8.4/8.5 x Laravel 12/13, with a Pin Laravel version step and the coverage publish gated on the PHP 8.3 / Laravel 13 leg).

Validated locally on PHP 8.3: composer validate passes, and each Laravel leg was pinned exactly as CI does (composer update --with="laravel/framework:^12.0" and ^13.0) - both resolved cleanly (v12.64.0 + testbench 10.11.0, v13.21.1 + testbench 11.1.0) and composer test:coverage passed on both (495 tests, 1297 assertions). The benchmark smoke step was also verified on the Laravel 13 leg.