### PR TITLE
ci: align the test matrix with the org standard

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,13 @@ jobs:
             -   name: Benchmark smoke
                 run: composer bench:smoke
 
+            -   name: Publish code coverage
+                if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.php == '8.3' }}
+                uses: qltysh/qlty-action/coverage@v2
+                with:
+                    oidc: true
+                    files: clover.xml
+
     # ==========================================================================
     # JOB: LARAVEL TESTS
     # ==========================================================================
@@ -98,14 +105,7 @@ jobs:
                 run: composer update --with="laravel/framework:${LARAVEL_CONSTRAINT}" --prefer-dist --no-interaction --no-progress
 
             -   name: PHPUnit
-                run: composer test:coverage
+                run: composer test
 
             -   name: Benchmark smoke
                 run: composer bench:smoke
-
-            -   name: Publish code coverage
-                if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.laravel.label == '13' }}
-                uses: qltysh/qlty-action/coverage@v2
-                with:
-                    oidc: true
-                    files: clover.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,23 +51,15 @@ jobs:
                         laravel:
                             constraint: ^12.0
                             label: 12
+                    -   php: 8.4
+                        laravel:
+                            constraint: ^12.0
+                            label: 12
+                    -   php: 8.5
+                        laravel:
+                            constraint: ^12.0
+                            label: 12
                     -   php: 8.3
-                        laravel:
-                            constraint: ^13.0
-                            label: 13
-                    -   php: 8.4
-                        laravel:
-                            constraint: ^12.0
-                            label: 12
-                    -   php: 8.4
-                        laravel:
-                            constraint: ^13.0
-                            label: 13
-                    -   php: 8.5
-                        laravel:
-                            constraint: ^12.0
-                            label: 12
-                    -   php: 8.5
                         laravel:
                             constraint: ^13.0
                             label: 13
@@ -95,7 +87,7 @@ jobs:
                 run: composer bench:smoke
 
             -   name: Publish code coverage
-                if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.php == '8.3' && matrix.laravel.label == '13' }}
+                if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.laravel.label == '13' }}
                 uses: qltysh/qlty-action/coverage@v2
                 with:
                     oidc: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,32 +37,16 @@ defaults:
 jobs:
 
     # ==========================================================================
-    # JOB: TESTS
+    # JOB: PHP TESTS
     # ==========================================================================
-    tests:
-        name: Test / PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel.label }}
+    php:
+        name: Test / PHP ${{ matrix.php }}
         runs-on: ubuntu-latest
 
         strategy:
             fail-fast: false
             matrix:
-                include:
-                    -   php: 8.3
-                        laravel:
-                            constraint: ^12.0
-                            label: 12
-                    -   php: 8.4
-                        laravel:
-                            constraint: ^12.0
-                            label: 12
-                    -   php: 8.5
-                        laravel:
-                            constraint: ^12.0
-                            label: 12
-                    -   php: 8.3
-                        laravel:
-                            constraint: ^13.0
-                            label: 13
+                php: [ 8.3, 8.4, 8.5 ]
 
         steps:
             -   name: Checkout
@@ -74,6 +58,39 @@ jobs:
                 uses: sinemacula/.github/.github/actions/setup-php@v1.1.1
                 with:
                     php-version: ${{ matrix.php }}
+
+            -   name: PHPUnit
+                run: composer test:coverage
+
+            -   name: Benchmark smoke
+                run: composer bench:smoke
+
+    # ==========================================================================
+    # JOB: LARAVEL TESTS
+    # ==========================================================================
+    laravel:
+        name: Test / Laravel ${{ matrix.laravel.label }}
+        runs-on: ubuntu-latest
+
+        strategy:
+            fail-fast: false
+            matrix:
+                laravel:
+                    -   constraint: ^12.0
+                        label: 12
+                    -   constraint: ^13.0
+                        label: 13
+
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v5
+                with:
+                    persist-credentials: false
+
+            -   name: Setup PHP
+                uses: sinemacula/.github/.github/actions/setup-php@v1.1.1
+                with:
+                    php-version: 8.3
 
             -   name: Pin Laravel version
                 env:


### PR DESCRIPTION
Converts the tests workflow to the org's two-job standard: a PHP compatibility job testing PHP 8.3/8.4/8.5 with unpinned dependencies (resolving the newest supported Laravel), and a Laravel compatibility job pinning Laravel 12 and 13 via `composer update --with` on PHP 8.3.

The coverage publish is gated on the PHP job's 8.3 leg. The benchmark smoke step runs in both jobs.

The mutation scripts already carry the org-standard flags (`--threads=max`, `--ignore-msi-with-no-mutations`), so no composer changes were needed.

Validated with a YAML parse of the workflow and a full `composer test` run (495 tests passing).

