### PR TITLE
chore: apply the current coding standards

### DIFF
--- a/benchmarks/Support/Sources/ArraySource.php
+++ b/benchmarks/Support/Sources/ArraySource.php
@@ -14,7 +14,7 @@ use SineMacula\Exporter\Contracts\Source;
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
-final class ArraySource implements Source
+final readonly class ArraySource implements Source
 {
     /**
      * Create the source.
@@ -24,7 +24,7 @@ final class ArraySource implements Source
     public function __construct(
 
         /** @var list<SourceRow> The items yielded by the source */
-        private readonly array $items,
+        private array $items,
     ) {}
 
     /**

--- a/benchmarks/Writers/StreamingCsvBench.php
+++ b/benchmarks/Writers/StreamingCsvBench.php
@@ -26,7 +26,7 @@ use SineMacula\Exporter\Writers\CsvWriter;
  * @copyright   2026 Sine Macula Limited.
  */
 #[Bench\OutputTimeUnit('milliseconds')]
-final class StreamingCsvBench
+final readonly class StreamingCsvBench
 {
     /** @var int The small scale dataset size. */
     private const int ROWS_10K = 10000;
@@ -38,7 +38,7 @@ final class StreamingCsvBench
     private const int ROWS_1M = 1000000;
 
     /** @var \Benchmarks\Support\Schema\ScaleSchema The fixed three-column schema shared by every benchmark subject */
-    private readonly ScaleSchema $schema;
+    private ScaleSchema $schema;
 
     /**
      * Create the benchmark with its fixed, stateless schema.

--- a/benchmarks/Writers/TabularWriterBench.php
+++ b/benchmarks/Writers/TabularWriterBench.php
@@ -58,6 +58,8 @@ final class TabularWriterBench
      * Benchmark CSV writer throughput with mixed typed cells.
      *
      * @return void
+     *
+     * @throws \DateMalformedStringException
      */
     #[Bench\BeforeMethods('setUp')]
     #[Bench\Iterations(5)]
@@ -72,6 +74,8 @@ final class TabularWriterBench
      * Benchmark TSV writer throughput with mixed typed cells.
      *
      * @return void
+     *
+     * @throws \DateMalformedStringException
      */
     #[Bench\BeforeMethods('setUp')]
     #[Bench\Iterations(5)]
@@ -86,6 +90,10 @@ final class TabularWriterBench
      * Benchmark XLSX writer throughput with mixed typed cells.
      *
      * @return void
+     *
+     * @throws \DateMalformedStringException
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
     #[Bench\BeforeMethods('setUp')]
     #[Bench\Iterations(3)]
@@ -105,6 +113,8 @@ final class TabularWriterBench
      *
      * @param  int  $count
      * @return \Generator<int, array<string, \SineMacula\Exporter\Schema\CellValue>>
+     *
+     * @throws \DateMalformedStringException
      */
     private function rows(int $count): \Generator
     {

--- a/src/Contracts/HierarchicalWriter.php
+++ b/src/Contracts/HierarchicalWriter.php
@@ -34,6 +34,8 @@ interface HierarchicalWriter
      * @param  iterable<int, array<array-key, mixed>>  $items
      * @param  \SineMacula\Exporter\Contracts\Sink  $sink
      * @return void
+     *
+     * @throws \Throwable
      */
     public function write(iterable $items, Sink $sink): void;
 }

--- a/src/Contracts/Writer.php
+++ b/src/Contracts/Writer.php
@@ -33,6 +33,8 @@ interface Writer
      * @param  \SineMacula\Exporter\Schema\TabularSchema  $schema
      * @param  \SineMacula\Exporter\Contracts\Sink  $sink
      * @return void
+     *
+     * @throws \Throwable
      */
     public function write(iterable $rows, TabularSchema $schema, Sink $sink): void;
 }

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -469,7 +469,7 @@ final readonly class Engine
 
         try {
             return $column->toCellValue($item, $request, $this->registry);
-        } catch (\Throwable $exception) {
+        } catch (\Throwable $exception) { // @phpstan-ignore catch.neverThrown
             $warnings->add("Column [{$column->getKey()}] blanked: {$exception->getMessage()}.");
 
             return new CellValue(null, CellType::NULL);
@@ -494,7 +494,7 @@ final readonly class Engine
 
         try {
             return $column->toChildCellValue($child, $request, $this->registry);
-        } catch (\Throwable $exception) {
+        } catch (\Throwable $exception) { // @phpstan-ignore catch.neverThrown
             $warnings->add("Column [{$column->getKey()}] blanked: {$exception->getMessage()}.");
 
             return new CellValue(null, CellType::NULL);

--- a/src/Jobs/ExportToDiskJob.php
+++ b/src/Jobs/ExportToDiskJob.php
@@ -180,7 +180,7 @@ final class ExportToDiskJob implements ShouldQueue
     {
         try {
             $auditor->completed($event);
-        } catch (\Throwable $exception) {
+        } catch (\Throwable $exception) { // @phpstan-ignore catch.neverThrown
             Log::warning('Queued export completed, but completion handling failed.', [
                 'disk'      => $this->spec->disk,
                 'path'      => $this->spec->path,
@@ -211,15 +211,18 @@ final class ExportToDiskJob implements ShouldQueue
     /**
      * Determine whether the destination path existed before this attempt.
      *
+     * An unreadable destination is reported as pre-existing, so a probe that
+     * cannot answer never authorises the cleanup delete.
+     *
      * @param  \Illuminate\Contracts\Filesystem\Filesystem  $disk
-     * @return bool|null
+     * @return bool
      */
-    private function hasExistingTarget(Filesystem $disk): ?bool
+    private function hasExistingTarget(Filesystem $disk): bool
     {
         try {
             return $disk->exists($this->spec->path);
-        } catch (\Throwable) {
-            return null;
+        } catch (\Throwable) { // @phpstan-ignore catch.neverThrown
+            return true;
         }
     }
 
@@ -228,19 +231,19 @@ final class ExportToDiskJob implements ShouldQueue
      * destination.
      *
      * @param  \Illuminate\Contracts\Filesystem\Filesystem  $disk
-     * @param  bool|null  $targetExisted
+     * @param  bool  $targetExisted
      * @param  bool  $storageAttempted
      * @return void
      */
-    private function cleanupFailedStorageAttempt(Filesystem $disk, ?bool $targetExisted, bool $storageAttempted): void
+    private function cleanupFailedStorageAttempt(Filesystem $disk, bool $targetExisted, bool $storageAttempted): void
     {
-        if (!$storageAttempted || $targetExisted !== false) {
+        if (!$storageAttempted || $targetExisted) {
             return;
         }
 
         try {
             $disk->delete($this->spec->path);
-        } catch (\Throwable $exception) {
+        } catch (\Throwable $exception) { // @phpstan-ignore catch.neverThrown
             Log::warning('Unable to remove a failed queued export file.', [
                 'disk'      => $this->spec->disk,
                 'path'      => $this->spec->path,

--- a/src/ResourceExport.php
+++ b/src/ResourceExport.php
@@ -209,6 +209,7 @@ final class ResourceExport
      * @throws \LogicException
      * @throws \SineMacula\Exporter\Exceptions\NoTabularRepresentation
      * @throws \SineMacula\Exporter\Exceptions\RowLimitExceeded
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function paginatedJsonOrStreamedExport(?Request $request = null): Response
     {
@@ -270,6 +271,7 @@ final class ResourceExport
      * @throws \LogicException
      * @throws \SineMacula\Exporter\Exceptions\NoTabularRepresentation
      * @throws \SineMacula\Exporter\Exceptions\RowLimitExceeded
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     private function streamResponse(ExportNegotiator $negotiator, string $format, Request $request): Response
     {
@@ -305,6 +307,7 @@ final class ResourceExport
      *
      * @throws \LogicException
      * @throws \SineMacula\Exporter\Exceptions\RowLimitExceeded
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     private function streamHierarchicalResponse(ExportNegotiator $negotiator, HierarchicalWriter $writer, string $format, Request $request): Response
     {
@@ -384,6 +387,8 @@ final class ResourceExport
      * @param  \SineMacula\Exporter\Export\ExportAuditor  $auditor
      * @param  \Illuminate\Http\Request  $request
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     private function authorizeFullSet(ExportAuditor $auditor, Request $request): void
     {

--- a/src/Schema/Casters/DateCaster.php
+++ b/src/Schema/Casters/DateCaster.php
@@ -44,6 +44,8 @@ final readonly class DateCaster implements Caster
      * @param  mixed  $value
      * @param  array<string, mixed>  $options
      * @return \SineMacula\Exporter\Schema\CellValue
+     *
+     * @throws \DateInvalidTimeZoneException
      */
     #[\Override]
     public function cast(mixed $value, array $options = []): CellValue

--- a/src/Sinks/DiskSink.php
+++ b/src/Sinks/DiskSink.php
@@ -19,7 +19,7 @@ use SineMacula\Exporter\Exceptions\SinkException;
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
  */
-final class DiskSink implements Sink
+final readonly class DiskSink implements Sink
 {
     /**
      * Constructor.
@@ -32,13 +32,13 @@ final class DiskSink implements Sink
     public function __construct(
 
         /** The storage disk the file is uploaded to. */
-        private readonly Filesystem $disk,
+        private Filesystem $disk,
 
         /** The destination path on the disk. */
-        private readonly string $path,
+        private string $path,
 
         /** The write options forwarded to the disk. */
-        private readonly array $options = [],
+        private array $options = [],
     ) {}
 
     /**

--- a/src/Writers/CountingWriter.php
+++ b/src/Writers/CountingWriter.php
@@ -58,6 +58,8 @@ final readonly class CountingWriter implements Writer
      * @param  \SineMacula\Exporter\Schema\TabularSchema  $schema
      * @param  \SineMacula\Exporter\Contracts\Sink  $sink
      * @return void
+     *
+     * @throws \Throwable
      */
     #[\Override]
     public function write(iterable $rows, TabularSchema $schema, Sink $sink): void

--- a/src/Writers/CsvWriter.php
+++ b/src/Writers/CsvWriter.php
@@ -137,6 +137,8 @@ final readonly class CsvWriter implements Writer
      * @param  \League\Csv\Writer  $writer
      * @param  \SineMacula\Exporter\Contracts\Sink  $sink
      * @return void
+     *
+     * @throws \League\Csv\Exception
      */
     private function markTruncated(LeagueWriter $writer, Sink $sink): void
     {
@@ -150,6 +152,9 @@ final readonly class CsvWriter implements Writer
      *
      * @param  \SineMacula\Exporter\Contracts\Sink  $sink
      * @return \League\Csv\Writer
+     *
+     * @throws \League\Csv\InvalidArgument
+     * @throws \League\Csv\UnavailableStream
      */
     private function makeWriter(Sink $sink): LeagueWriter
     {

--- a/src/Writers/XlsxWriter.php
+++ b/src/Writers/XlsxWriter.php
@@ -83,6 +83,8 @@ final readonly class XlsxWriter implements Writer
      * @throws \SineMacula\Exporter\Exceptions\MissingXlsxDependency
      * @throws \SineMacula\Exporter\Exceptions\XlsxRowLimitExceeded
      * @throws \SineMacula\Exporter\Exceptions\SinkException
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
     #[\Override]
     public function write(iterable $rows, TabularSchema $schema, Sink $sink): void
@@ -130,6 +132,8 @@ final readonly class XlsxWriter implements Writer
      * @return void
      *
      * @throws \SineMacula\Exporter\Exceptions\XlsxRowLimitExceeded
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
     private function build(iterable $rows, TabularSchema $schema, string $path): void
     {

--- a/tests/Integration/Export/ResourceExportTest.php
+++ b/tests/Integration/Export/ResourceExportTest.php
@@ -36,6 +36,8 @@ final class ResourceExportTest extends ExporterTestCase
      * It returns a single paginated page of JSON for a JSON request.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testJsonRequestReturnsASinglePaginatedPage(): void
     {
@@ -59,6 +61,8 @@ final class ResourceExportTest extends ExporterTestCase
      * request.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testExportRequestStreamsMoreThanOnePage(): void
     {
@@ -82,6 +86,8 @@ final class ResourceExportTest extends ExporterTestCase
      * It rejects non-key ordering before building a streamed response.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testExportRequestRejectsNonKeyOrderingBeforeStreaming(): void
     {
@@ -99,6 +105,8 @@ final class ResourceExportTest extends ExporterTestCase
      * It enforces the row cap before any bytes are streamed.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testRowCapIsEnforcedBeforeStreaming(): void
     {
@@ -122,6 +130,8 @@ final class ResourceExportTest extends ExporterTestCase
      * It lifts the cap with unlimited().
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testUnlimitedLiftsTheCap(): void
     {
@@ -146,6 +156,8 @@ final class ResourceExportTest extends ExporterTestCase
      * functional guarantees proven above.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testLargeExportStreamsAtBoundedPeakMemory(): void
     {
@@ -174,6 +186,8 @@ final class ResourceExportTest extends ExporterTestCase
      * It fires the audit hook with the pinned payload once the stream finishes.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testAuditHookFiresWithThePinnedPayload(): void
     {
@@ -204,6 +218,8 @@ final class ResourceExportTest extends ExporterTestCase
      * It returns 406 when the export resource declares no tabular schema.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testExportWithoutATabularSchemaYields406(): void
     {
@@ -221,6 +237,8 @@ final class ResourceExportTest extends ExporterTestCase
      * It streams explicit hierarchical export requests over the full dataset.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testHierarchicalExportRequestStreamsTheFullDataset(): void
     {
@@ -250,6 +268,8 @@ final class ResourceExportTest extends ExporterTestCase
      * It paginates by the built-in default page size of fifteen.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testPerPageDefaultsToFifteen(): void
     {
@@ -269,6 +289,8 @@ final class ResourceExportTest extends ExporterTestCase
      * It reads the configured page size, casting a numeric string to an int.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testPerPageReadsTheConfiguredNumericString(): void
     {
@@ -290,6 +312,8 @@ final class ResourceExportTest extends ExporterTestCase
      * It streams when the row count exactly equals the configured cap.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testRowCapAllowsExactlyTheMaximum(): void
     {
@@ -309,6 +333,8 @@ final class ResourceExportTest extends ExporterTestCase
      * decision - neither authorizeUsing() nor withoutAuthorization().
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testStreamingWithoutAnAuthorizationDecisionThrows(): void
     {
@@ -325,6 +351,8 @@ final class ResourceExportTest extends ExporterTestCase
      * withoutAuthorization().
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testWithoutAuthorizationPermitsStreaming(): void
     {
@@ -343,6 +371,8 @@ final class ResourceExportTest extends ExporterTestCase
      * check actually runs against the full-set query.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testAuthorizeUsingPermitsStreaming(): void
     {
@@ -369,6 +399,8 @@ final class ResourceExportTest extends ExporterTestCase
      * export before any byte is streamed.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testAuthorizeUsingRejectsAForbiddenActor(): void
     {
@@ -387,6 +419,8 @@ final class ResourceExportTest extends ExporterTestCase
      * It rejects a forbidden actor when authorizeUsing() returns false.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testAuthorizeUsingRejectsFalse(): void
     {
@@ -403,6 +437,8 @@ final class ResourceExportTest extends ExporterTestCase
      * It dispatches the pinned ExportCompleted event with an integer actor id.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testStreamedExportDispatchesExportCompletedWithIntegerActor(): void
     {
@@ -429,6 +465,8 @@ final class ResourceExportTest extends ExporterTestCase
      * It resolves a string actor identifier into the audit payload.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testStreamedExportResolvesAStringActorIdentifier(): void
     {
@@ -451,6 +489,8 @@ final class ResourceExportTest extends ExporterTestCase
      * It records a null actor id when the request carries no user.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testStreamedExportRecordsNullActorWithoutAUser(): void
     {

--- a/tests/Integration/Export/SecurityTest.php
+++ b/tests/Integration/Export/SecurityTest.php
@@ -98,6 +98,8 @@ final class SecurityTest extends ExporterTestCase
      * The streamed full-set query export is denied before any byte is sent.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testFullSetAuthorizationIsReCheckedBeforeStreaming(): void
     {
@@ -116,6 +118,8 @@ final class SecurityTest extends ExporterTestCase
      * An authorized full-set query export streams the entire dataset.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testAuthorizedFullSetStreamsTheEntireDataset(): void
     {

--- a/tests/Integration/Jobs/ExportToDiskJobTest.php
+++ b/tests/Integration/Jobs/ExportToDiskJobTest.php
@@ -665,6 +665,69 @@ final class ExportToDiskJobTest extends QueuedExportTestCase
     }
 
     /**
+     * It leaves the destination alone after a failed storage attempt when the
+     * disk could not answer whether that destination already existed.
+     *
+     * @return void
+     */
+    public function testDoesNotDeleteTheDestinationWhenTheExistenceProbeFails(): void
+    {
+        $disk = \Mockery::mock(Filesystem::class);
+
+        /** @var \Mockery\Expectation $existsExpectation */
+        $existsExpectation = $disk->shouldReceive('exists');
+        $existsExpectation->once()->with('exports/boom.csv')->andThrow(new \RuntimeException('probe failed'));
+
+        /** @var \Mockery\Expectation $writeStreamExpectation */
+        $writeStreamExpectation = $disk->shouldReceive('writeStream');
+        $writeStreamExpectation->once()->andThrow(new \RuntimeException('upload failed'));
+
+        $disk->shouldNotReceive('delete');
+
+        $factory = new readonly class ($disk) implements Factory {
+            /**
+             * Create a new single-disk filesystem factory.
+             *
+             * @param  \Illuminate\Contracts\Filesystem\Filesystem  $disk
+             */
+            public function __construct(
+
+                /** The disk every name resolves to. */
+                private Filesystem $disk,
+            ) {}
+
+            /**
+             * Resolve a filesystem disk by name.
+             *
+             * @param  mixed  $name
+             * @return \Illuminate\Contracts\Filesystem\Filesystem
+             */
+            #[\Override]
+            public function disk(mixed $name = null): Filesystem
+            {
+                return $this->disk;
+            }
+        };
+
+        $this->seedUsers(1);
+
+        $job = new ExportToDiskJob(
+            QueuedExport::forModel(User::class, UserResource::class)
+                ->toDisk('exports', 'exports/boom.csv')
+                ->withoutAuthorization()
+                ->toSpecification(),
+        );
+
+        try {
+            app()->call([$job, 'handle'], ['filesystem' => $factory]);
+
+            self::fail('Expected the storage failure to be re-thrown.');
+        } catch (\RuntimeException $exception) {
+            self::assertSame('upload failed', $exception->getMessage());
+        }
+    }
+
+    /**
      * It does not delete a destination that existed before a failed export
      * attempt.
      *

--- a/tests/Unit/Export/ExportAuditorTest.php
+++ b/tests/Unit/Export/ExportAuditorTest.php
@@ -35,6 +35,8 @@ final class ExportAuditorTest extends ExporterTestCase
      * fluent re-check).
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testAuthorizeRunsTheCallback(): void
     {
@@ -51,6 +53,8 @@ final class ExportAuditorTest extends ExporterTestCase
      * It throws when the caller-supplied authorization callback denies access.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testAuthorizeThrowsWhenTheCallbackReturnsFalse(): void
     {
@@ -64,6 +68,8 @@ final class ExportAuditorTest extends ExporterTestCase
      * serializable re-check).
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testAuthorizeAllowsAGrantedAbility(): void
     {
@@ -85,6 +91,8 @@ final class ExportAuditorTest extends ExporterTestCase
      * It throws when the gate denies the ability for the actor.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testAuthorizeThrowsOnADeniedAbility(): void
     {
@@ -103,6 +111,8 @@ final class ExportAuditorTest extends ExporterTestCase
      * It is a no-op when neither a callback nor an ability is given.
      *
      * @return void
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function testAuthorizeIsANoOpWithoutCallbackOrAbility(): void
     {

--- a/tests/Unit/Facades/ExporterFacadeTest.php
+++ b/tests/Unit/Facades/ExporterFacadeTest.php
@@ -85,8 +85,6 @@ final class ExporterFacadeTest extends TestCase
      * Invoke the protected facade accessor on the real facade.
      *
      * @return string
-     *
-     * @throws \ReflectionException
      */
     private function invokeFacadeAccessor(): string
     {

--- a/tests/Unit/Schema/CastRegistryTest.php
+++ b/tests/Unit/Schema/CastRegistryTest.php
@@ -97,6 +97,8 @@ final class CastRegistryTest extends TestCase
      * It returns a null cell for an unparseable date.
      *
      * @return void
+     *
+     * @throws \DateInvalidTimeZoneException
      */
     public function testDateCasterReturnsNullForUnparseableValue(): void
     {

--- a/tests/Unit/Schema/CastersTest.php
+++ b/tests/Unit/Schema/CastersTest.php
@@ -38,6 +38,8 @@ final class CastersTest extends TestCase
      * It casts a DateTimeInterface into a date cell carrying the format hint.
      *
      * @return void
+     *
+     * @throws \DateInvalidTimeZoneException
      */
     public function testDateCasterAcceptsADateTimeInstance(): void
     {
@@ -53,6 +55,8 @@ final class CastersTest extends TestCase
      * It parses a UNIX timestamp from both an integer and a digit string.
      *
      * @return void
+     *
+     * @throws \DateInvalidTimeZoneException
      */
     public function testDateCasterParsesTimestamps(): void
     {
@@ -69,6 +73,8 @@ final class CastersTest extends TestCase
      * It applies a timezone option and falls back when the format is not text.
      *
      * @return void
+     *
+     * @throws \DateInvalidTimeZoneException
      */
     public function testDateCasterAppliesTimezoneAndFormatFallback(): void
     {
@@ -89,6 +95,8 @@ final class CastersTest extends TestCase
      * hint, proving the option wins over the default.
      *
      * @return void
+     *
+     * @throws \DateInvalidTimeZoneException
      */
     public function testDateCasterUsesAStringFormatOption(): void
     {
@@ -101,6 +109,8 @@ final class CastersTest extends TestCase
      * It yields a null cell for an unparseable or empty date string.
      *
      * @return void
+     *
+     * @throws \DateInvalidTimeZoneException
      */
     public function testDateCasterReturnsNullForUnparseableValues(): void
     {

--- a/tests/Unit/Writers/JsonWriterTest.php
+++ b/tests/Unit/Writers/JsonWriterTest.php
@@ -110,6 +110,8 @@ final class JsonWriterTest extends TestCase
      * It raises a sink exception when a write to the stream fails.
      *
      * @return void
+     *
+     * @throws \Throwable
      */
     public function testThrowsWhenAWriteToTheStreamFails(): void
     {

--- a/tests/Unit/Writers/XlsxStreamingMemoryTest.php
+++ b/tests/Unit/Writers/XlsxStreamingMemoryTest.php
@@ -40,6 +40,9 @@ final class XlsxStreamingMemoryTest extends TestCase
      * It streams a large tabular XLSX export at bounded peak memory.
      *
      * @return void
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
     public function testLargeXlsxExportStreamsAtBoundedMemory(): void
     {

--- a/tests/Unit/Writers/XlsxWriterTest.php
+++ b/tests/Unit/Writers/XlsxWriterTest.php
@@ -46,6 +46,9 @@ final class XlsxWriterTest extends TestCase
      * seekable sink.
      *
      * @return void
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
     public function testGoldenReadBackEmitsHeadingAndTypedCells(): void
     {
@@ -91,6 +94,9 @@ final class XlsxWriterTest extends TestCase
      * the finalise-then-putFromFile path.
      *
      * @return void
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
     public function testNonSeekableSinkProducesReadableWorkbook(): void
     {
@@ -116,6 +122,9 @@ final class XlsxWriterTest extends TestCase
      * non-scalars.
      *
      * @return void
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
     public function testRendersTypedCellEdgeCases(): void
     {
@@ -174,6 +183,9 @@ final class XlsxWriterTest extends TestCase
      * It renders a date cell whose raw value is not a date through its string.
      *
      * @return void
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
     public function testRendersANonDateRawForADateCell(): void
     {
@@ -192,6 +204,9 @@ final class XlsxWriterTest extends TestCase
      * It omits the heading row when the schema disables headings.
      *
      * @return void
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
     public function testHeadingsCanBeDisabled(): void
     {
@@ -213,6 +228,9 @@ final class XlsxWriterTest extends TestCase
      * It writes an empty, readable workbook for an empty row set.
      *
      * @return void
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
     public function testEmptySetProducesEmptyWorkbook(): void
     {
@@ -230,6 +248,9 @@ final class XlsxWriterTest extends TestCase
      * It humanises a dotted column key into a spaced heading.
      *
      * @return void
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
     public function testDottedKeyHeadingIsHumanised(): void
     {
@@ -250,6 +271,9 @@ final class XlsxWriterTest extends TestCase
      * not a stringified fallback.
      *
      * @return void
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
     public function testRendersDateTimeCellAsNativeDate(): void
     {
@@ -274,6 +298,9 @@ final class XlsxWriterTest extends TestCase
      * segments and falling back to the false label for a false value.
      *
      * @return void
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
     public function testBooleanLabelsFromPipeDelimitedFormat(): void
     {
@@ -395,6 +422,9 @@ final class XlsxWriterTest extends TestCase
      * @param  \Illuminate\Http\Request  $request
      * @param  list<array<string, mixed>>  $items
      * @return list<list<mixed>>
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
     private function export(array $columns, Request $request, array $items): array
     {


### PR DESCRIPTION
The standards package is distributed automatically, but Qlty Cloud only analyses the diff of the update PR - so the newly shipped rules were never run against the existing code. This runs the full ruleset (`qlty check --all`, `qlty fmt`, `qlty smells`) over the whole repository and resolves what it reported.

Thirty-one findings. The exception-declaration work is mechanical; two items needed a judgement call and are called out below.

## Checked exceptions that were never declared

Most of the count. `League\Csv\Exception`, `InvalidArgument`, `UnavailableStream`, the two OpenSpout exceptions, `DateInvalidTimeZoneException`, `DateMalformedStringException` and `AuthorizationException` are all checked under the shared config, so every method they cross has to declare them.

I converged this by re-running the analyser after each pass rather than tagging the reported list in one go - declaring a checked exception on a callee makes every caller a throw site in its own right. That mattered here: it took four rounds to settle, and a single pass would have left the gate red.

## Writer contracts under-declared their own failure mode

`JsonWriter`, `NdjsonWriter`, `XmlWriter` and `CsvWriter` all document `@throws \Throwable` on `write()`, but neither the `Writer` nor `HierarchicalWriter` interface did, and nor did the `CountingWriter` decorator. Declared it on all three.

This is worth having on its own - the interfaces were quietly narrower than every implementation - and it also resolves the dead-catch report on `ExportNegotiator::streamHierarchical()`. That catch is what emits the truncation marker and fires `StreamExportFailed`; it only looked dead because the contract claimed `write()` could not fail. Confirmed no cascade: the negotiator consumes the exception, so nothing above it needed a new tag.

## `hasExistingTarget()` returned a three-state it never used

The analyser reported that the `?bool` return never actually returns null. Rather than suppress that, I narrowed it to `bool` and made the failure path return `true`, meaning "treat an unreadable destination as pre-existing".

The guarantee is unchanged and is the one that matters: `cleanupFailedStorageAttempt()` must never delete a destination this attempt did not create. Previously an indeterminate probe returned null and the caller tested `!== false`; now it returns true and the caller tests the flag directly. What the old shape did *not* have was anything holding that invariant in place - no test covered an indeterminate probe followed by a failed store, so nothing stopped the failure path being changed to return `false`, which would delete a pre-existing export. `testDoesNotDeleteTheDestinationWhenTheExistenceProbeFails` now pins it; I verified it fails if the fail-safe is inverted.

Concretely, the scenario this protects: a disk that permits writes but denies or intermittently fails existence checks (an S3 bucket policy without `HeadObject`, or a throttling window). The probe throws, the store then fails, and cleanup must not remove the export already sitting at that path.

## Remaining dead-catch reports

Five kept and marked with `@phpstan-ignore catch.neverThrown`, matching how the same false positive is handled elsewhere in the org. Each is reachable and covered:

- `Engine::cell()` and `Engine::childCell()` - guard user-supplied resolvers, casters and formatters; this is the whole lenient-strictness contract. Covered by `testLenientBlanksAThrowingCellAndCollectsAWarning` and `testLenientBlanksAThrowingExpandedChildCell`.
- `ExportToDiskJob::reportCompleted()` - stops a throwing audit listener from unwinding into the handler that deletes the stored export. Covered by `testKeepsTheStoredFileWhenCompletionHandlingFailsAfterStoring`.
- `ExportToDiskJob::hasExistingTarget()` and `cleanupFailedStorageAttempt()` - guard disk adapters that can raise on `exists()` and `delete()`.

I did test conforming these the same way as the writer contracts, by declaring the throw on `Caster::cast()` and the `Column` cell pipeline. It does not pay off: it pushes a bare `@throws \Throwable` onto the public schema API and cascades through the shared `ShapesRows` test trait, which is the noise the shared config's own commentary warns against. Two inline markers are the smaller price.

## Also fixed

`ArraySource`, `StreamingCsvBench` and `DiskSink` promoted to readonly classes, and a stale `@throws \ReflectionException` removed from a facade test helper (the config treats `ReflectionException` as unchecked, so the tag was noise).

## Two things I found but did not change

Both predate this branch and are behaviour changes rather than standards fixes, so they belong in their own PR if you want them:

1. `XlsxWriter::write()` now publishes raw OpenSpout exception types on an interface method, for a dependency that is only suggested and is guarded by `class_exists`. Everywhere else that class wraps IO failures in `SinkException`. Wrapping them there too would keep the published contract inside the `ExporterException` family.
2. `CsvWriter::markTruncated()` can itself throw, and it is called from inside `write()`'s catch block before the rethrow - so a broken sink stream can surface the marker's `League\Csv\Exception` instead of the original cause, and `failStream()` then reports the wrong exception. `JsonWriter`, `XmlWriter` and `NdjsonWriter` share the shape. Making the marker non-throwing would fix it.

## Verification

- `qlty check --all --no-cache` - no issues
- `qlty fmt --all` - no changes
- `qlty smells --all` - 22 findings, identical count before and after this branch (pre-existing wide parameter lists on the event value objects and `Engine`)
- `composer test` - 496 passed, 1301 assertions (495 before, plus the new one)